### PR TITLE
fix: initial load error

### DIFF
--- a/src/components/editor.tsx
+++ b/src/components/editor.tsx
@@ -14,7 +14,7 @@ export const Editor: FC<EditorProperties> = (properties) => {
     <MonacoEditor
       height="100%"
       beforeMount={(monaco) => {
-        monaco?.editor.defineTheme("eslint-light", {
+        monaco.editor.defineTheme("eslint-light", {
           base: "vs",
           inherit: true,
           rules: [],
@@ -23,7 +23,7 @@ export const Editor: FC<EditorProperties> = (properties) => {
           },
         });
 
-        monaco?.editor.defineTheme("eslint-dark", {
+        monaco.editor.defineTheme("eslint-dark", {
           base: "vs-dark",
           inherit: true,
           rules: [],


### PR DESCRIPTION
fixes https://github.com/eslint/code-explorer/issues/4

this was caused as monaco editor values where trying to be set twice during render. If we do before editor mount it should work fine. try if you are still able to see the error in this branch.