### PR TITLE
fix: use Espree exported latestEcmaVersion

### DIFF
--- a/src/components/scope/index.tsx
+++ b/src/components/scope/index.tsx
@@ -33,7 +33,10 @@ export const Scope: FC = () => {
 	// eslint-scope types are on DefinitelyTyped and haven't been updated.
 	const scopeManager = eslintScope.analyze(ast, {
 		sourceType: explorer.sourceType as never,
-		ecmaVersion: explorer.esVersion as never,
+		ecmaVersion:
+			explorer.esVersion === "latest"
+				? espree.latestEcmaVersion
+				: explorer.esVersion,
 	});
 
 	return (


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

-   [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request?
Fix editor breakage that occurs when selecting the "latest" ECMAScript option and clicking on the scope tab.

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)
`eslint-scope` doesn’t support the `latest` option. so, use the `latestEcmaVersion` exported by `espree` to determine the corresponding version for "latest".
#### Related Issues

#### Is there anything you'd like reviewers to focus on?

<!-- markdownlint-disable-file MD004 -->
