### PR TITLE
fix: fixed code path re-rendering issue

### DIFF
--- a/src/components/path/index.tsx
+++ b/src/components/path/index.tsx
@@ -52,12 +52,11 @@ export const CodePath: FC = () => {
 		},
 		500,
 		[
-			explorer,
 			explorer.jsCode,
 			explorer.esVersion,
 			explorer.sourceType,
-			explorer.setPathIndexes,
 			explorer.pathIndexes,
+			explorer.pathIndex,
 		],
 	);
 


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

-   [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request?
In JavaScript, when attempting to preview the code path, the editor component ends up being re-rendered continuously.


<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)
Updated the `useDebouncedEffect` dependency array to address the re-rendering issue by:
- Removing `explorer` and `explorer.setPathIndexes`
- Adding `explorer.pathIndex`

Before:

https://github.com/user-attachments/assets/06c258da-c37f-49a8-9641-81c271863736 

After:

https://github.com/user-attachments/assets/f98521ef-9c04-4814-a5fa-05d75bceec6d


#### Related Issues

#### Is there anything you'd like reviewers to focus on?

<!-- markdownlint-disable-file MD004 -->



