### PR TITLE
chore: use css for capitalizing instead of JS

### DIFF
--- a/src/components/ast/javascript-ast-tree-item.tsx
+++ b/src/components/ast/javascript-ast-tree-item.tsx
@@ -1,4 +1,3 @@
-import { capitalize } from "@/lib/utils";
 import {
 	AccordionContent,
 	AccordionItem,
@@ -23,8 +22,8 @@ export const JavascriptAstTreeItem: FC<JavascriptAstTreeItemProperties> = ({
 		value={`${index}-${data.type}`}
 		className="border rounded-lg overflow-hidden"
 	>
-		<AccordionTrigger className="text-sm bg-muted-foreground/5 px-4 py-3">
-			{capitalize(data.type)}
+		<AccordionTrigger className="text-sm bg-muted-foreground/5 px-4 py-3 capitalize">
+			{data.type}
 		</AccordionTrigger>
 		<AccordionContent className="p-4 border-t">
 			<div className="space-y-1">

--- a/src/components/ast/json-ast-tree-item.tsx
+++ b/src/components/ast/json-ast-tree-item.tsx
@@ -1,4 +1,3 @@
-import { capitalize } from "@/lib/utils";
 import {
 	AccordionContent,
 	AccordionItem,
@@ -25,8 +24,8 @@ export const JsonAstTreeItem: FC<JsonAstTreeItemProperties> = ({
 		value={`${index}-${data.type}`}
 		className="border rounded-lg overflow-hidden"
 	>
-		<AccordionTrigger className="text-sm bg-muted-foreground/5 px-4 py-3">
-			{capitalize(data.type)}
+		<AccordionTrigger className="text-sm bg-muted-foreground/5 px-4 py-3 capitalize">
+			{data.type}
 		</AccordionTrigger>
 		<AccordionContent className="p-4 border-t">
 			<div className="space-y-1">

--- a/src/components/ast/markdown-ast-tree-item.tsx
+++ b/src/components/ast/markdown-ast-tree-item.tsx
@@ -1,4 +1,3 @@
-import { capitalize } from "@/lib/utils";
 import {
 	AccordionContent,
 	AccordionItem,
@@ -25,8 +24,8 @@ export const MarkdownAstTreeItem: FC<MarkdownAstTreeItemProperties> = ({
 		value={`${index}-${data.type}`}
 		className="border rounded-lg overflow-hidden"
 	>
-		<AccordionTrigger className="text-sm bg-muted-foreground/5 px-4 py-3">
-			{capitalize(data.type)}
+		<AccordionTrigger className="text-sm bg-muted-foreground/5 px-4 py-3 capitalize">
+			{data.type}
 		</AccordionTrigger>
 		<AccordionContent className="p-4 border-t">
 			<div className="space-y-1">

--- a/src/components/scope/scope-item.tsx
+++ b/src/components/scope/scope-item.tsx
@@ -1,5 +1,4 @@
 import { Scope, Variable, Reference } from "eslint-scope";
-import { capitalize } from "@/lib/utils";
 import {
 	AccordionContent,
 	AccordionItem,
@@ -31,8 +30,8 @@ export const ScopeItem: FC<ScopeItemProperties> = ({ data, index }) => {
 			value={`${index}-${key}`}
 			className="border rounded-lg overflow-hidden"
 		>
-			<AccordionTrigger className="text-sm bg-muted-foreground/5 px-4 py-3">
-				{Math.max(index, 0)}. {capitalize(key)}
+			<AccordionTrigger className="text-sm bg-muted-foreground/5 px-4 py-3 capitalize">
+				{Math.max(index, 0)}. {key}
 			</AccordionTrigger>
 			<AccordionContent className="p-4 border-t">
 				<div className="space-y-1">

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -4,9 +4,7 @@ import type { ClassValue } from "clsx";
 
 export const cn = (...inputs: ClassValue[]): string => twMerge(clsx(inputs));
 
-export const capitalize = (substring: string): string =>
-	substring.charAt(0).toUpperCase() + substring.slice(1);
-
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
 export function debounce<T extends (...args: any[]) => void>(
 	func: T,
 	delay: number,


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

-   [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request?

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)
- capitalize can be done with css we won't need a JS util to do it