### PR TITLE
fix: code path issue

### DIFF
--- a/src/components/path/index.tsx
+++ b/src/components/path/index.tsx
@@ -36,7 +36,7 @@ export const CodePath: FC = () => {
 				})
 				.then(newExtracted => {
 					if (
-						newExtracted.codePathList.length > explorer.pathIndexes
+						newExtracted.codePathList.length < explorer.pathIndexes
 					) {
 						explorer.setPathIndex(0);
 					}


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

-   [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request?
Fixed code path preview breakage. 

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)
1. Add JavaScript code to generate code paths and select any option from the code path dropdown, except for the first option code path 1. 

2. Afterwards, remove some of the code that generated the code path. As a result, the code preview will break, displaying the following error. 

![image](https://github.com/user-attachments/assets/5ce44d38-e122-4794-8b5e-17c2b8e9338b)


#### Related Issues

#### Is there anything you'd like reviewers to focus on?

<!-- markdownlint-disable-file MD004 -->
