### PR TITLE
fix:  fix error message styles

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -38,8 +38,6 @@
 		--drop-container-bg-color: 0deg 0% 77.59% / 80%;
 		--drop-message-bg-color: 0deg 0% 20%;
 
-		--danger: 0deg 61.61% 56.08%;
-
 		--scrollbar-track: 0deg 0% 93.33%;
 		--scrollbar-thumb: 0deg 0% 53.33%;
 		--scrollbar-thumb-hover: 0deg 0% 33.33%;
@@ -78,8 +76,6 @@
 
 		--drop-container-bg-color: 0deg 0% 24.71% / 67%;
 		--drop-message-bg-color: 0deg 0% 20%;
-
-		--danger: 0deg 61.61% 56.08%;
 
 		--scrollbar-track: 0deg 0% 18.04%;
 		--scrollbar-thumb: 0deg 0% 53.33%;

--- a/src/components/error-boundary.tsx
+++ b/src/components/error-boundary.tsx
@@ -43,8 +43,10 @@ export const withErrorBoundary = (Children: FC) => {
 
 export const ErrorState = ({ message }: { message: string }) => {
 	return (
-		<div className="bg-background pl-1.5 pt-1.5 h-full">
-			<div className="p-4 text-danger">Error: {message}</div>
+		<div className="bg-red-50 dark:bg-gray-800 pl-1.5 pt-1.5 h-full">
+			<div className="p-4 text-red-600 dark:text-red-400">
+				Error: {message}
+			</div>
 		</div>
 	);
 };

--- a/src/components/path/index.tsx
+++ b/src/components/path/index.tsx
@@ -62,8 +62,10 @@ export const CodePath: FC = () => {
 
 	if (error) {
 		return (
-			<div className="bg-background pl-1.5 pt-1.5 h-full">
-				<div className="p-4 text-danger">Error: {error}</div>
+			<div className="bg-red-50 dark:bg-gray-900 pl-1.5 pt-1.5 h-full">
+				<div className="p-4 text-red-600 dark:text-red-400">
+					Error: {error}
+				</div>
 			</div>
 		);
 	}

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -50,7 +50,6 @@ module.exports = {
 				},
 				dropContainer: "hsl(var(--drop-container-bg-color))",
 				dropMessage: "hsl(var(--drop-message-bg-color))",
-				danger: "hsl(var(--danger))",
 				editorBackground: "hsl(var(--editor-background))",
 			},
 			borderRadius: {


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

-   [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request?
Fixed error message styling.
<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

The error message in the right panel was always displayed with a white background, regardless of the theme colour. I've adjusted the styles to ensure the error background now matches the theme color.

Light theme:
![image](https://github.com/user-attachments/assets/609c36ff-86e7-43fe-b7a8-212966f9ee64)


Dark theme:
![image](https://github.com/user-attachments/assets/732a3cfe-7303-4f1e-80c7-6378bd499898)


#### Related Issues

#### Is there anything you'd like reviewers to focus on?

<!-- markdownlint-disable-file MD004 -->
