### PR TITLE
fix: Remove tool bottom border

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -23,7 +23,7 @@ function App() {
 								}}
 							/>
 							<div className="bg-foreground/5 overflow-auto h-[70dvh] sm:h-full relative flex flex-col">
-								<div className="flex sm:items-center flex-col sm:flex-row justify-between p-4 gap-2 z-10 border-b">
+								<div className="flex sm:items-center flex-col sm:flex-row justify-between p-4 gap-2 z-10">
 									<ToolSelector />
 									<div className="flex items-center gap-1">
 										{activeTool.options.map(


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

-   [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request?

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

The toolbar had a bottom border, which meant that the topmost tree item was right up against it. The border isn't in the original design, so I removed it.
![Screenshot 2024-09-27 at 11-19-35 ESLint Code Explorer](https://github.com/user-attachments/assets/049a2484-36bf-4a90-8621-7b0c79c89bc2)




#### Related Issues

#### Is there anything you'd like reviewers to focus on?

<!-- markdownlint-disable-file MD004 -->
