### PR TITLE
fix: panel height issue

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -22,7 +22,7 @@ function App() {
 									setCode({ ...code, [language]: value });
 								}}
 							/>
-							<div className="bg-foreground/5 overflow-auto h-[70dvh] sm:h-full relative flex flex-col">
+							<div className="bg-foreground/5 overflow-auto h-[calc(100vh-80px)] sm:h-full relative flex flex-col">
 								<div className="flex sm:items-center flex-col sm:flex-row justify-between p-4 gap-2 z-10">
 									<ToolSelector />
 									<div className="flex items-center gap-1">

--- a/src/components/ast/javascript-ast.tsx
+++ b/src/components/ast/javascript-ast.tsx
@@ -33,7 +33,7 @@ export const JavascriptAst: FC = () => {
 		return (
 			<Accordion
 				type="multiple"
-				className="px-8 font-mono space-y-3"
+				className="px-8 pb-2 font-mono space-y-3"
 				defaultValue={["0-Program"]}
 			>
 				<JavascriptAstTreeItem data={tree} index={0} />

--- a/src/components/ast/json-ast.tsx
+++ b/src/components/ast/json-ast.tsx
@@ -25,7 +25,7 @@ export const JsonAst: FC = () => {
 		return (
 			<Accordion
 				type="multiple"
-				className="px-8 font-mono space-y-3"
+				className="px-8 pb-2 font-mono space-y-3"
 				defaultValue={["0-Document"]}
 			>
 				<JsonAstTreeItem data={result.ast} index={0} />

--- a/src/components/ast/markdown-ast.tsx
+++ b/src/components/ast/markdown-ast.tsx
@@ -25,7 +25,7 @@ export const MarkdownAst: FC = () => {
 		return (
 			<Accordion
 				type="multiple"
-				className="px-8 font-mono space-y-3"
+				className="px-8 pb-2 font-mono space-y-3"
 				defaultValue={["0-root"]}
 			>
 				<MarkdownAstTreeItem data={result.ast} index={0} />

--- a/src/components/editor.tsx
+++ b/src/components/editor.tsx
@@ -114,7 +114,7 @@ export const Editor: FC<EditorProperties> = ({ readOnly, value, onChange }) => {
 
 	const editorClasses = clsx("relative", {
 		"h-[calc(100vh-152px)]": readOnly,
-		"h-[calc(100vh-72px)]": !readOnly,
+		"h-[calc(100vh-80px)]": !readOnly,
 	});
 
 	const dropMessageClasses = clsx(

--- a/src/components/scope/index.tsx
+++ b/src/components/scope/index.tsx
@@ -40,7 +40,7 @@ export const Scope: FC = () => {
 	return (
 		<Accordion
 			type="multiple"
-			className="px-8 font-mono space-y-3"
+			className="px-8 pb-2 font-mono space-y-3"
 			defaultValue={["0-global"]}
 		>
 			{scopeView === "flat" ? (


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

-   [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request?

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

1. Set the same height (`calc(100vh - 80px)`) for both the right and left panels to be consistent.
2. Added padding to the bottom of the accordions to create some space at the end.

#### Related Issues
Fixes #50 
#### Is there anything you'd like reviewers to focus on?

<!-- markdownlint-disable-file MD004 -->
