### PR TITLE
fix: Tree view should be the default AST view

### DIFF
--- a/src/lib/const.ts
+++ b/src/lib/const.ts
@@ -345,7 +345,7 @@ export const defaultPathIndex: PathIndex = {
 };
 
 export const defaultViewModes: ViewModes = {
-	astView: "json",
+	astView: "tree",
 	scopeView: "flat",
 	pathView: "graph",
 };


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

-   [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request?

Set the tree view as the default for ASTs.

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

Updated the default setting for AST view to be `tree`

#### Related Issues

#### Is there anything you'd like reviewers to focus on?

<!-- markdownlint-disable-file MD004 -->
