### PR TITLE
fix: wrap option

### DIFF
--- a/src/components/wrap.tsx
+++ b/src/components/wrap.tsx
@@ -7,24 +7,28 @@ import { Button } from "./ui/button";
 import type { FC } from "react";
 
 export const Wrap: FC = () => {
-	const explorer = useExplorer();
+	const {
+		tool,
+		viewModes: { astView, pathView },
+		wrap,
+		setWrap,
+	} = useExplorer();
 
-	if (explorer.tool === "ast" && explorer.astViewMode !== "json") {
+	if (tool === "ast" && astView !== "json") {
 		return null;
 	}
 
-	if (explorer.tool === "path" && explorer.pathViewMode !== "code") {
+	if (tool === "path" && pathView !== "code") {
 		return null;
 	}
 
 	return (
 		<Button
-			onClick={() => explorer.setWrap(!explorer.wrap)}
-			variant={explorer.wrap ? "outline" : "ghost"}
+			onClick={() => setWrap(!wrap)}
+			variant={wrap ? "outline" : "ghost"}
 			className={cn(
 				"flex items-center gap-2",
-				!explorer.wrap &&
-					"text-muted-foreground border border-transparent",
+				!wrap && "text-muted-foreground border border-transparent",
 			)}
 		>
 			<WrapTextIcon size={16} />

--- a/src/components/wrap.tsx
+++ b/src/components/wrap.tsx
@@ -14,13 +14,10 @@ export const Wrap: FC = () => {
 		setWrap,
 	} = useExplorer();
 
-	if (tool === "ast" && astView !== "json") {
-		return null;
-	}
+	const isAstViewNotJson = tool === "ast" && astView !== "json";
+	const isPathViewNotCode = tool === "path" && pathView !== "code";
 
-	if (tool === "path" && pathView !== "code") {
-		return null;
-	}
+	if (isAstViewNotJson || isPathViewNotCode) return null;
 
 	return (
 		<Button


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

-   [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request?

The wrap option was previously broken and not visible in the UI. It has now been fixed and is displaying correctly.

As part of making code generic PR (https://github.com/eslint/code-explorer/pull/44), we restructured the explorer state, which caused the wrap feature to break. I'm not sure how it was missed. 😶
<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

#### Related Issues

#### Is there anything you'd like reviewers to focus on?

<!-- markdownlint-disable-file MD004 -->
