### PR TITLE
fix: Acknowledge JSX option in JS mode

### DIFF
--- a/src/components/ast/javascript-ast.tsx
+++ b/src/components/ast/javascript-ast.tsx
@@ -18,6 +18,9 @@ export const JavascriptAst: FC = () => {
 		tree = espree.parse(explorer.code.javascript, {
 			ecmaVersion: explorer.jsOptions.esVersion,
 			sourceType: explorer.jsOptions.sourceType,
+			ecmaFeatures: {
+				jsx: explorer.jsOptions.isJSX,
+			},
 		});
 
 		ast = JSON.stringify(tree, null, 2);

--- a/src/components/path/index.tsx
+++ b/src/components/path/index.tsx
@@ -31,6 +31,7 @@ export const CodePath: FC = () => {
 				javascript,
 				esVersion,
 				sourceType,
+				jsOptions.isJSX,
 			);
 			if ("error" in response) {
 				throw new Error(response.error);

--- a/src/lib/generate-code-path.ts
+++ b/src/lib/generate-code-path.ts
@@ -59,6 +59,7 @@ export const generateCodePath = async (
 	code: string,
 	esVersion: Version,
 	sourceType: SourceType,
+	isJSX: boolean,
 ): Promise<
 	| {
 			error: string;
@@ -127,6 +128,11 @@ export const generateCodePath = async (
 		languageOptions: {
 			ecmaVersion: esVersion,
 			sourceType,
+			parserOptions: {
+				ecmaFeatures: {
+					jsx: isJSX,
+				},
+			},
 		},
 	};
 


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

-   [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request?

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

Ensured that we are reading the value of the JSX toggle in JavaScript mode.

#### Related Issues

Fixes #73

#### Is there anything you'd like reviewers to focus on?

<!-- markdownlint-disable-file MD004 -->
