### PR TITLE
feat: Add CSS tolerant parsing mode

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@codemirror/lang-json": "^6.0.1",
         "@codemirror/lang-markdown": "^6.2.5",
         "@codemirror/language": "^6.10.3",
-        "@eslint/css": "^0.1.0",
+        "@eslint/css": "^0.2.0",
         "@eslint/js": "^9.9.0",
         "@eslint/json": "^0.4.1",
         "@eslint/markdown": "^6.1.1",
@@ -1161,9 +1161,9 @@
       }
     },
     "node_modules/@eslint/css": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/@eslint/css/-/css-0.1.0.tgz",
-      "integrity": "sha512-ColcXSHsncUU3FO6Y9OrGKECPrnJezKoTaKKIRtqWZ0Kr5x/9B411fdnSFQ6e1+BI2pfKWcC6cPchiEmb57wsA==",
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/@eslint/css/-/css-0.2.0.tgz",
+      "integrity": "sha512-m6BhqDKBatcPyY2DFNQ1gxf7VMiQysejylBcwHHZ63BMnthNqSAHJsmaPemtFA95DHlfVvu07FK7mu/p0QHheQ==",
       "dependencies": {
         "@eslint/plugin-kit": "^0.2.3",
         "css-tree": "^3.0.1"

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "@codemirror/lang-json": "^6.0.1",
     "@codemirror/lang-markdown": "^6.2.5",
     "@codemirror/language": "^6.10.3",
-    "@eslint/css": "^0.1.0",
+    "@eslint/css": "^0.2.0",
     "@eslint/js": "^9.9.0",
     "@eslint/json": "^0.4.1",
     "@eslint/markdown": "^6.1.1",

--- a/src/components/ast/css-ast.tsx
+++ b/src/components/ast/css-ast.tsx
@@ -10,9 +10,14 @@ import { ErrorState } from "../error-boundary";
 export const CssAst: FC = () => {
 	const { code, cssOptions, viewModes } = useExplorer();
 	const { astView } = viewModes;
-	const { cssMode } = cssOptions;
+	const { cssMode, tolerant } = cssOptions;
 	const language = css.languages[cssMode];
-	const result = language.parse({ body: code.css });
+	const result = language.parse(
+		{ body: code.css },
+		{
+			languageOptions: { tolerant },
+		},
+	);
 
 	if (!result.ok) {
 		const message = parseError(result.errors[0]);

--- a/src/components/options.tsx
+++ b/src/components/options.tsx
@@ -67,7 +67,23 @@ const MarkdownPanel: React.FC = () => {
 };
 
 const CssPanel: React.FC = () => {
-	return null;
+	const explorer = useExplorer();
+	const { cssOptions, setCssOptions } = explorer;
+	const { tolerant } = cssOptions;
+	return (
+		<>
+			<div className="flex items-center gap-1.5">
+				<Switch
+					id="tolerant"
+					checked={tolerant}
+					onCheckedChange={(value: boolean) => {
+						setCssOptions({ ...cssOptions, tolerant: value });
+					}}
+				/>
+				<Label htmlFor="tolerant">Tolerant Parsing</Label>
+			</div>
+		</>
+	);
 };
 
 const JavaScriptPanel = () => {

--- a/src/components/options.tsx
+++ b/src/components/options.tsx
@@ -71,18 +71,16 @@ const CssPanel: React.FC = () => {
 	const { cssOptions, setCssOptions } = explorer;
 	const { tolerant } = cssOptions;
 	return (
-		<>
-			<div className="flex items-center gap-1.5">
-				<Switch
-					id="tolerant"
-					checked={tolerant}
-					onCheckedChange={(value: boolean) => {
-						setCssOptions({ ...cssOptions, tolerant: value });
-					}}
-				/>
-				<Label htmlFor="tolerant">Tolerant Parsing</Label>
-			</div>
-		</>
+		<div className="flex items-center gap-1.5">
+			<Switch
+				id="tolerant"
+				checked={tolerant}
+				onCheckedChange={(value: boolean) => {
+					setCssOptions({ ...cssOptions, tolerant: value });
+				}}
+			/>
+			<Label htmlFor="tolerant">Tolerant Parsing</Label>
+		</div>
 	);
 };
 

--- a/src/hooks/use-explorer.ts
+++ b/src/hooks/use-explorer.ts
@@ -45,6 +45,7 @@ export type MarkdownOptions = {
 
 export type CssOptions = {
 	cssMode: CssMode;
+	tolerant: boolean;
 };
 
 export type PathIndex = {

--- a/src/lib/const.ts
+++ b/src/lib/const.ts
@@ -385,6 +385,7 @@ export const defaultMarkdownOptions: MarkdownOptions = {
 
 export const defaultCssOptions: CssOptions = {
 	cssMode: "css",
+	tolerant: false,
 };
 
 export const defaultPathIndex: PathIndex = {


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

-   [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request?

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

Updated the CSS language with a "tolerant" parsing mode toggle. 

![Screenshot 2025-01-21 162816](https://github.com/user-attachments/assets/84295bbe-9b65-4a77-b89b-ebecbf0fe543)


#### Related Issues

Refs https://github.com/eslint/css/issues/29

#### Is there anything you'd like reviewers to focus on?

<!-- markdownlint-disable-file MD004 -->
