### PR TITLE
fix: do not partially hide CM selection background on active lines

### DIFF
--- a/src/utils/codemirror-themes.tsx
+++ b/src/utils/codemirror-themes.tsx
@@ -17,7 +17,10 @@ export const ESLintPlaygroundTheme = EditorView.theme(
 			paddingRight: "1px",
 			backgroundColor: "var(--body-background-color)",
 		},
-		".cm-activeLine, .cm-activeLineGutter": {
+		".cm-activeLine": {
+			backgroundColor: "transparent",
+		},
+		".cm-activeLineGutter": {
 			backgroundColor: "var(--body-background-color)",
 		},
 		".cm-content": {
@@ -53,7 +56,6 @@ export const ESLintPlaygroundTheme = EditorView.theme(
 			margin: "0",
 		},
 		"&.cm-editor .cm-content .cm-line ::selection": {
-			backgroundColor: "var(--color-primary-800) !important",
 			color: "#fff !important",
 		},
 	},


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

-   [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request?

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

CodeMirror's selection functionality works by rendering elements with `cm-selectionBackground` class behind the text with the desired color.  
In order for that to work, the text itself must not have any color - it must have a transparent background.  
But a CSS rule gave the active line the default background color, therefore those `cm-selectionBackground` elements were not visible.

The reason that parts of the selection appeared selected was only because this rule applied, which was probably a workaround for the non working selection: https://github.com/eslint/code-explorer/blob/89a913c65ac3b069f3daa85f36229059b93fb9e6/src/utils/codemirror-themes.tsx#L56.

#### Related Issues

fixes #81 

#### Is there anything you'd like reviewers to focus on?

<!-- markdownlint-disable-file MD004 -->
