### PR TITLE
Revert "chore: avoid react linting errors"

### DIFF
--- a/src/components/editor.tsx
+++ b/src/components/editor.tsx
@@ -53,11 +53,9 @@ export const Editor: FC<EditorProperties> = ({ readOnly, value, onChange }) => {
 	];
 
 	const debouncedOnChange = useCallback(
-		(value: string) => {
-			debounce(() => {
-				onChange?.(value);
-			}, 400)();
-		},
+		debounce((value: string) => {
+			onChange?.(value);
+		}, 400),
 		[onChange],
 	);
 

--- a/src/components/path/index.tsx
+++ b/src/components/path/index.tsx
@@ -59,7 +59,6 @@ export const CodePath: FC = () => {
 
 	useEffect(() => {
 		fetchCodePath();
-		// eslint-disable-next-line react-hooks/exhaustive-deps -- we want to fetch code path once on mount, afterwards the "useDebouncedEffect" takes over
 	}, []);
 
 	useDebouncedEffect(


### PR DESCRIPTION
This change is causing some issues when typing quickly in the editor. so reverting the change for now we will have to solve this in a different approach. 

Reverts eslint/code-explorer#83

