### PR TITLE
chore: avoid react linting errors (attempt #2)

### DIFF
--- a/src/components/editor.tsx
+++ b/src/components/editor.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useRef, useState, FC, useCallback } from "react";
+import { useEffect, useRef, useState, FC, useMemo } from "react";
 import { useExplorer } from "@/hooks/use-explorer";
 import CodeMirror from "@uiw/react-codemirror";
 import { json } from "@codemirror/lang-json";
@@ -63,10 +63,11 @@ export const Editor: FC<EditorProperties> = ({
 		highlightedRangesExtension(highlightedRanges),
 	];
 
-	const debouncedOnChange = useCallback(
-		debounce((value: string) => {
-			onChange?.(value);
-		}, 400),
+	const debouncedOnChange = useMemo(
+		() =>
+			debounce((value: string) => {
+				onChange?.(value);
+			}, 400),
 		[onChange],
 	);
 

--- a/src/components/path/index.tsx
+++ b/src/components/path/index.tsx
@@ -59,6 +59,7 @@ export const CodePath: FC = () => {
 
 	useEffect(() => {
 		fetchCodePath();
+		// eslint-disable-next-line react-hooks/exhaustive-deps -- we want to fetch code path once on mount, afterwards the "useDebouncedEffect" takes over
 	}, []);
 
 	useDebouncedEffect(


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

-   [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request?

Attempt #<span/>2 (after #83) to unblock #70.  
By avoiding the 2 linting errors already present in the codebase.

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

This time, I did not introduce any behavior changes.  
I just replaced `useCallback` by `useMemo` because then the warning `React Hook useCallback received a function whose dependencies are unknown` vanishes.

* chore: disable warning for `useEffect` for code path on mount
* chore: avoid warning by replacing `useCallback` by `useMemo`

#### Related Issues

#### Is there anything you'd like reviewers to focus on?

<!-- markdownlint-disable-file MD004 -->
