### PR TITLE
fix: tree view horizontal scrolling to prevent node collapse

### DIFF
--- a/src/components/ast/css-ast.tsx
+++ b/src/components/ast/css-ast.tsx
@@ -26,7 +26,7 @@ export const CssAst: FC = () => {
 		return (
 			<Accordion
 				type="multiple"
-				className="px-8 font-mono space-y-3"
+				className="px-8 font-mono space-y-3 min-w-max"
 				defaultValue={["0-StyleSheet"]}
 			>
 				<CssAstTreeItem

--- a/src/components/ast/javascript-ast.tsx
+++ b/src/components/ast/javascript-ast.tsx
@@ -31,7 +31,7 @@ export const JavascriptAst: FC = () => {
 		return (
 			<Accordion
 				type="multiple"
-				className="px-8 font-mono space-y-3"
+				className="px-8 font-mono space-y-3 min-w-max"
 				defaultValue={["0-Program"]}
 			>
 				<JavascriptAstTreeItem

--- a/src/components/ast/json-ast.tsx
+++ b/src/components/ast/json-ast.tsx
@@ -26,7 +26,7 @@ export const JsonAst: FC = () => {
 		return (
 			<Accordion
 				type="multiple"
-				className="px-8 font-mono space-y-3"
+				className="px-8 font-mono space-y-3 min-w-max"
 				defaultValue={["0-Document"]}
 			>
 				<JsonAstTreeItem

--- a/src/components/ast/markdown-ast.tsx
+++ b/src/components/ast/markdown-ast.tsx
@@ -26,7 +26,7 @@ export const MarkdownAst: FC = () => {
 		return (
 			<Accordion
 				type="multiple"
-				className="px-8 font-mono space-y-3"
+				className="px-8 font-mono space-y-3 min-w-max"
 				defaultValue={["0-root"]}
 			>
 				<MarkdownAstTreeItem

--- a/src/components/scope/index.tsx
+++ b/src/components/scope/index.tsx
@@ -37,7 +37,7 @@ export const Scope: FC = () => {
 	return (
 		<Accordion
 			type="multiple"
-			className="px-8 font-mono space-y-3"
+			className="px-8 font-mono space-y-3 min-w-max"
 			defaultValue={["0-global"]}
 		>
 			{scopeView === "flat" ? (


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

-   [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request?

When expanding nodes in the tree view, they begin to collapse at deeper levels, making them impossible to read or use. This pull request addresses this issue.

#### Related Issues

Fixes #77

#### Is there anything you'd like reviewers to focus on?

<!-- markdownlint-disable-file MD004 -->
