### PR TITLE
refactor: remove accordion behavior for non-array nodes

### DIFF
--- a/src/components/scope/scope-item.tsx
+++ b/src/components/scope/scope-item.tsx
@@ -46,18 +46,43 @@ export const ScopeItem: FC<ScopeItemProperties> = ({
 		([name]) => !name.startsWith("__"),
 	);
 
+	if (isArray) {
+		return (
+			<AccordionItem
+				value={path + "." + index + "." + key}
+				className={cn(
+					"border border-card rounded-lg overflow-hidden",
+					isEsqueryMatchedNode && "border-primary border-4",
+				)}
+			>
+				<AccordionTrigger className="text-sm bg-card px-4 py-3 capitalize">
+					{`${Math.max(index, 0)}. ${key}`}
+				</AccordionTrigger>
+				<AccordionContent className="p-4 border-t">
+					<div className="space-y-1">
+						{properties.map((item, index) => (
+							<TreeEntry
+								key={item[0]}
+								data={item}
+								path={path + "." + index}
+								esqueryMatchedNodes={esqueryMatchedNodes}
+							/>
+						))}
+					</div>
+				</AccordionContent>
+			</AccordionItem>
+		);
+	}
+
 	return (
-		<AccordionItem
-			value={path + "." + index + "." + key}
+		<div
 			className={cn(
 				"border border-card rounded-lg overflow-hidden",
 				isEsqueryMatchedNode && "border-primary border-4",
 			)}
 		>
-			<AccordionTrigger className="text-sm bg-card px-4 py-3 capitalize">
-				{isArray && `${Math.max(index, 0)}.`} {key}
-			</AccordionTrigger>
-			<AccordionContent className="p-4 border-t">
+			<h3 className="text-sm bg-card px-4 py-3 capitalize">{key}</h3>
+			<div className="p-4 border-t">
 				<div className="space-y-1">
 					{properties.map((item, index) => (
 						<TreeEntry
@@ -68,7 +93,7 @@ export const ScopeItem: FC<ScopeItemProperties> = ({
 						/>
 					))}
 				</div>
-			</AccordionContent>
-		</AccordionItem>
+			</div>
+		</div>
 	);
 };


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

-   [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request?

This PR simplifies the AST tree view by removing the accordion behavior for non-array nodes while maintaining it for array items.

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

- Removes the collapsible behavior for regular AST nodes
- Keeps the accordion functionality for array items

#### Related Issues

Closes #71

#### Is there anything you'd like reviewers to focus on?

<!-- markdownlint-disable-file MD004 -->
