### PR TITLE
feat: make tree entry keys toggleable

### DIFF
--- a/src/components/tree-entry.tsx
+++ b/src/components/tree-entry.tsx
@@ -101,15 +101,16 @@ export const TreeEntry: FC<TreeEntryProperties> = ({
 	const [key, value] = data;
 	const [open, setOpen] = useState(false);
 	const Icon = open ? MinusSquareIcon : PlusSquareIcon;
+	const isToggleable =
+		(typeof value === "object" && Object.values(value ?? {}).length) ||
+		(Array.isArray(value) && value.length);
 
 	const toggleOpen = () => setOpen(!open);
 
 	return (
 		<>
 			<div className="flex items-center gap-3">
-				{(typeof value === "object" &&
-					Object.values(value ?? {}).length) ||
-				(Array.isArray(value) && value.length) ? (
+				{isToggleable ? (
 					<button
 						onClick={toggleOpen}
 						aria-label="Toggle"
@@ -120,7 +121,18 @@ export const TreeEntry: FC<TreeEntryProperties> = ({
 				) : (
 					<div className="w-4 h-4" />
 				)}
-				{key && <span>{key}</span>}
+				{key &&
+					(isToggleable ? (
+						<button
+							onClick={toggleOpen}
+							type="button"
+							className="hover:underline"
+						>
+							{key}
+						</button>
+					) : (
+						<span>{key}</span>
+					))}
 				{renderValue(value).map((part, partIndex) => (
 					<span
 						key={partIndex}


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

-   [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request?

This PR improves the usability and accessibility of the tree entry component by making the key text toggleable, in addition to the existing icon button, matching the behavior of other AST explorers like astexplorer.net and typescript-eslint playground.

#### What changes did you make? (Give an overview)

- Made the key text clickable when the entry is toggleable

#### Related Issues

#### Is there anything you'd like reviewers to focus on?

<!-- markdownlint-disable-file MD004 -->
