### PR TITLE
chore: rename `fmt` script to follow general convention

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,4 +47,4 @@ jobs:
 
             - name: Check formatting of everything (prettier)
               run: |
-                  npm run fmt
+                  npm run fmt:check

--- a/package.json
+++ b/package.json
@@ -17,8 +17,8 @@
     "lint:fix": "npm-run-all --parallel lint:fix:*",
     "lint:js": "eslint --max-warnings 0 .",
     "lint:fix:js": "eslint --max-warnings 0 . --fix",
-    "fmt": "prettier --check .",
-    "fmt:fix": "prettier --write ."
+    "fmt": "prettier --write .",
+    "fmt:check": "prettier --check ."
   },
   "lint-staged": {
     "**/*.{ts,tsx,jsx,js}": [


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

-   [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request?

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

Hello,

I've renamed the `fmt` script to follow general convention.

The reason of this PR is described in https://github.com/eslint/eslint/pull/19686.

All other ESLint repositories use the `fmt` and `fmt:check` convention, but `code-explorer` was the only one not following it.

#### Related Issues

#### Is there anything you'd like reviewers to focus on?

<!-- markdownlint-disable-file MD004 -->
