### PR TITLE
feat: add support for `allowTrailingCommas` option in JSON

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "@codemirror/language": "^6.10.3",
         "@eslint/css": "^0.2.0",
         "@eslint/js": "^9.9.0",
-        "@eslint/json": "^0.4.1",
+        "@eslint/json": "^0.12.0",
         "@eslint/markdown": "^6.4.0",
         "@lezer/highlight": "^1.2.1",
         "@radix-ui/react-accordion": "^1.2.0",
@@ -1209,17 +1209,6 @@
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       }
     },
-    "node_modules/@eslint/css/node_modules/@eslint/plugin-kit": {
-      "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.2.3.tgz",
-      "integrity": "sha512-2b/g5hRmpbb1o4GnTZax9N9m0FXzz9OV42ZzI4rDDMDuHUqigAiQCEWChBWCY4ztAGVRjoWT19v0yMmc5/L5kA==",
-      "dependencies": {
-        "levn": "^0.4.1"
-      },
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      }
-    },
     "node_modules/@eslint/eslintrc": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-3.3.1.tgz",
@@ -1253,13 +1242,27 @@
       }
     },
     "node_modules/@eslint/json": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/@eslint/json/-/json-0.4.1.tgz",
-      "integrity": "sha512-pDW3UTVJJIyE8CDrtj7T4vxy08yksIgf2Ws16GKzHqZ8meu9eTf5bDtQxKQtUtJzUonvMIj5N/kLHG5MRnYyeA==",
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/@eslint/json/-/json-0.12.0.tgz",
+      "integrity": "sha512-n/7dz8HFStpEe4o5eYk0tdkBdGUS/ZGb0GQCeDWN1ZmRq67HMHK4vC33b0rQlTT6xdZoX935P4vstiWVk5Ying==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@eslint/plugin-kit": "^0.1.0",
-        "@humanwhocodes/momoa": "^3.2.0"
+        "@eslint/core": "^0.12.0",
+        "@eslint/plugin-kit": "^0.2.7",
+        "@humanwhocodes/momoa": "^3.3.4",
+        "natural-compare": "^1.4.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@eslint/json/node_modules/@eslint/core": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.12.0.tgz",
+      "integrity": "sha512-cmrR6pytBuSMTaBweKoGMwu3EiHiEC+DoyupPmlZ0HxBJBtIxwe+j/E4XPIKNx+Q74c8lXKPwYawBf5glsTkHg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@types/json-schema": "^7.0.15"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -1283,7 +1286,16 @@
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       }
     },
-    "node_modules/@eslint/markdown/node_modules/@eslint/plugin-kit": {
+    "node_modules/@eslint/object-schema": {
+      "version": "2.1.6",
+      "resolved": "https://registry.npmjs.org/@eslint/object-schema/-/object-schema-2.1.6.tgz",
+      "integrity": "sha512-RBMg5FRL0I0gs51M/guSAj5/e14VQ4tpZnQNWwuDT66P14I43ItmPfIZRhO9fUVIPOAQXU47atlywZ/czoqFPA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@eslint/plugin-kit": {
       "version": "0.2.8",
       "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.2.8.tgz",
       "integrity": "sha512-ZAoA40rNMPwSm+AeHpCq8STiNAwzWLJuP8Xv4CHIc9wv/PSuExjMrmjfYNj682vW0OOiZ1HKxzvjQr9XZIisQA==",
@@ -1296,34 +1308,13 @@
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       }
     },
-    "node_modules/@eslint/markdown/node_modules/@eslint/plugin-kit/node_modules/@eslint/core": {
+    "node_modules/@eslint/plugin-kit/node_modules/@eslint/core": {
       "version": "0.13.0",
       "resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.13.0.tgz",
       "integrity": "sha512-yfkgDw1KR66rkT5A8ci4irzDysN7FRpq3ttJolR88OqQikAWqwA8j5VZyas+vjyBNFIJ7MfybJ9plMILI2UrCw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@types/json-schema": "^7.0.15"
-      },
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      }
-    },
-    "node_modules/@eslint/object-schema": {
-      "version": "2.1.6",
-      "resolved": "https://registry.npmjs.org/@eslint/object-schema/-/object-schema-2.1.6.tgz",
-      "integrity": "sha512-RBMg5FRL0I0gs51M/guSAj5/e14VQ4tpZnQNWwuDT66P14I43ItmPfIZRhO9fUVIPOAQXU47atlywZ/czoqFPA==",
-      "license": "Apache-2.0",
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      }
-    },
-    "node_modules/@eslint/plugin-kit": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.1.0.tgz",
-      "integrity": "sha512-autAXT203ixhqei9xt+qkYOvY8l6LAFIdT2UXc/RPNeUVfqRF1BV94GTJyVPFKT8nFM6MyVJhjLj9E8JWvf5zQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "levn": "^0.4.1"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -1416,9 +1407,9 @@
       }
     },
     "node_modules/@humanwhocodes/momoa": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/@humanwhocodes/momoa/-/momoa-3.2.0.tgz",
-      "integrity": "sha512-xvLEGSmd8qxcqlKFnTxdnmqQFsYGC4GhpuhHgdFoZBV9zxvmSlTuasj2D3vei3IsBGmjP/ITwPFejNAG/w+jsw==",
+      "version": "3.3.8",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/momoa/-/momoa-3.3.8.tgz",
+      "integrity": "sha512-/3PZzor2imi/RLLcnHztkwA79txiVvW145Ve2cp5dxRcH5qOUNJPToasqLFHniTfw4B4lT7jGDdBOPXbXYlIMQ==",
       "license": "Apache-2.0",
       "engines": {
         "node": ">=18"
@@ -5016,19 +5007,6 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@types/json-schema": "^7.0.15"
-      },
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      }
-    },
-    "node_modules/eslint/node_modules/@eslint/plugin-kit": {
-      "version": "0.2.8",
-      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.2.8.tgz",
-      "integrity": "sha512-ZAoA40rNMPwSm+AeHpCq8STiNAwzWLJuP8Xv4CHIc9wv/PSuExjMrmjfYNj682vW0OOiZ1HKxzvjQr9XZIisQA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@eslint/core": "^0.13.0",
-        "levn": "^0.4.1"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "@codemirror/language": "^6.10.3",
     "@eslint/css": "^0.2.0",
     "@eslint/js": "^9.9.0",
-    "@eslint/json": "^0.4.1",
+    "@eslint/json": "^0.12.0",
     "@eslint/markdown": "^6.4.0",
     "@lezer/highlight": "^1.2.1",
     "@radix-ui/react-accordion": "^1.2.0",

--- a/src/components/options.tsx
+++ b/src/components/options.tsx
@@ -48,21 +48,23 @@ const JSONPanel: React.FC = () => {
 				placeholder="Mode"
 			/>
 
-			<div className="flex items-center gap-1.5">
-				<Switch
-					id="allowTrailingCommas"
-					checked={allowTrailingCommas}
-					onCheckedChange={(value: boolean) => {
-						setJsonOptions({
-							...jsonOptions,
-							allowTrailingCommas: value,
-						});
-					}}
-				/>
-				<Label htmlFor="allowTrailingCommas">
-					Allow Trailing Commas
-				</Label>
-			</div>
+			{jsonMode === "jsonc" && (
+				<div className="flex items-center gap-1.5">
+					<Switch
+						id="allowTrailingCommas"
+						checked={allowTrailingCommas}
+						onCheckedChange={(value: boolean) => {
+							setJsonOptions({
+								...jsonOptions,
+								allowTrailingCommas: value,
+							});
+						}}
+					/>
+					<Label htmlFor="allowTrailingCommas">
+						Allow Trailing Commas
+					</Label>
+				</div>
+			)}
 		</>
 	);
 };

--- a/src/components/options.tsx
+++ b/src/components/options.tsx
@@ -33,19 +33,37 @@ import type {
 const JSONPanel: React.FC = () => {
 	const explorer = useExplorer();
 	const { jsonOptions, setJsonOptions } = explorer;
-	const { jsonMode } = jsonOptions;
+	const { jsonMode, allowTrailingCommas } = jsonOptions;
 	return (
-		<LabeledSelect
-			id="jsonMode"
-			label="Mode"
-			value={jsonMode}
-			onValueChange={(value: string) => {
-				const jsonMode = value as JsonMode;
-				setJsonOptions({ ...jsonOptions, jsonMode });
-			}}
-			items={jsonModes}
-			placeholder="Mode"
-		/>
+		<>
+			<LabeledSelect
+				id="jsonMode"
+				label="Mode"
+				value={jsonMode}
+				onValueChange={(value: string) => {
+					const jsonMode = value as JsonMode;
+					setJsonOptions({ ...jsonOptions, jsonMode });
+				}}
+				items={jsonModes}
+				placeholder="Mode"
+			/>
+
+			<div className="flex items-center gap-1.5">
+				<Switch
+					id="allowTrailingCommas"
+					checked={allowTrailingCommas}
+					onCheckedChange={(value: boolean) => {
+						setJsonOptions({
+							...jsonOptions,
+							allowTrailingCommas: value,
+						});
+					}}
+				/>
+				<Label htmlFor="allowTrailingCommas">
+					Allow Trailing Commas
+				</Label>
+			</div>
+		</>
 	);
 };
 

--- a/src/hooks/use-ast.ts
+++ b/src/hooks/use-ast.ts
@@ -41,14 +41,21 @@ export function useAST() {
 		}
 
 		case "json": {
-			const { jsonMode } = jsonOptions;
+			const { jsonMode, allowTrailingCommas } = jsonOptions;
 			const language = json.languages[jsonMode];
-			astParseResult = language.parse({
-				body: code.json,
-				path: "",
-				physicalPath: "",
-				bom: false,
-			});
+			astParseResult = language.parse(
+				{
+					body: code.json,
+					path: "",
+					physicalPath: "",
+					bom: false,
+				},
+				{
+					languageOptions: {
+						allowTrailingCommas,
+					},
+				},
+			);
 			break;
 		}
 

--- a/src/hooks/use-explorer.ts
+++ b/src/hooks/use-explorer.ts
@@ -38,6 +38,7 @@ export type JsOptions = {
 
 export type JsonOptions = {
 	jsonMode: JsonMode;
+	allowTrailingCommas: boolean;
 };
 
 export type MarkdownOptions = {

--- a/src/lib/const.ts
+++ b/src/lib/const.ts
@@ -392,6 +392,7 @@ export const defaultJsOptions: JsOptions = {
 
 export const defaultJsonOptions: JsonOptions = {
 	jsonMode: "jsonc",
+	allowTrailingCommas: false,
 };
 
 export const defaultMarkdownOptions: MarkdownOptions = {


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

-   [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request?

Hello,

I've added support for the [`allowTrailingCommas`](https://github.com/eslint/json?tab=readme-ov-file#allowing-trailing-commas-in-jsonc) option in JSON.

Code Explorer can now parse trailing commas in JSONC mode!

Please let me know if there's anything I might have missed.

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

##### Before

![image](https://github.com/user-attachments/assets/d12a9f7b-3df8-4dbd-8f75-cb2f277d8786)

##### After

![image](https://github.com/user-attachments/assets/bd2747e9-3bb4-45e4-b997-2a4937e21cbf)

#### Related Issues

#### Is there anything you'd like reviewers to focus on?

<!-- markdownlint-disable-file MD004 -->
