### PR TITLE
fix: set default code when new language is selected

### DIFF
--- a/src/components/options.tsx
+++ b/src/components/options.tsx
@@ -15,6 +15,7 @@ import {
 	parsers,
 	sourceTypes,
 	versions,
+	defaultCode,
 } from "@/lib/const";
 import { Button } from "./ui/button";
 import { Label } from "./ui/label";
@@ -207,6 +208,13 @@ export const Options: FC = () => {
 	const handleChangeLanguage = (value: string) => {
 		const language = value as Language;
 		explorer.setLanguage(language);
+
+		if (explorer.code[language] === undefined) {
+			explorer.setCode({
+				...explorer.code,
+				[language]: defaultCode[language],
+			});
+		}
 
 		if (language !== "javascript" && explorer.tool !== "ast") {
 			explorer.setTool("ast");


### PR DESCRIPTION


#### Prerequisites checklist

-   [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request?

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)
- set a new language when its not found in explorer state
- https://github.com/eslint/code-explorer/issues/76#issuecomment-2868322632

#### Related Issues
- fixes https://github.com/eslint/code-explorer/issues/76

#### Is there anything you'd like reviewers to focus on?
- test if the changes are working fine 

<!-- markdownlint-disable-file MD004 -->
