### PR TITLE
fix: Adding missing field to store

### DIFF
--- a/src/hooks/use-explorer.ts
+++ b/src/hooks/use-explorer.ts
@@ -176,22 +176,20 @@ export const useExplorer = create<ExplorerState>()(
 				onRehydrateStorage: () => state => {
 					if (!state) return;
 
-					const code = (state.code ?? {}) as Partial<Code>;
+					let needsPatching = false;
+					const patchedCode = { ...defaultCode };
 
-					const hasMissing =
-						!code.javascript ||
-						!code.json ||
-						!code.markdown ||
-						!code.css;
+					(Object.keys(defaultCode) as (keyof Code)[]).forEach(
+						key => {
+							if (state.code && key in state.code) {
+								patchedCode[key] = state.code[key];
+							} else {
+								needsPatching = true;
+							}
+						},
+					);
 
-					if (hasMissing) {
-						const patchedCode: Code = {
-							javascript:
-								code.javascript ?? defaultCode.javascript,
-							json: code.json ?? defaultCode.json,
-							markdown: code.markdown ?? defaultCode.markdown,
-							css: code.css ?? defaultCode.css,
-						};
+					if (needsPatching) {
 						state.setCode(patchedCode);
 					}
 				},

--- a/src/hooks/use-explorer.ts
+++ b/src/hooks/use-explorer.ts
@@ -102,12 +102,10 @@ type ExplorerState = {
 	setEsquerySelector: (esquerySelector: EsquerySelector) => void;
 };
 
-// Helper function to get URLSearchParams from location hash
 const getHashParams = (): URLSearchParams => {
 	return new URLSearchParams(location.hash.slice(1));
 };
 
-// Optimized hash storage implementation
 const hashStorage: StateStorage = {
 	getItem: (key): string => {
 		const storedValue = getHashParams().get(key) ?? "";
@@ -129,46 +127,52 @@ const hashStorage: StateStorage = {
 export const useExplorer = create<ExplorerState>()(
 	devtools(
 		persist(
-			set => ({
-				tool: "ast",
-				setTool: tool => set({ tool }),
+			persist(
+				set => ({
+					tool: "ast",
+					setTool: tool => set({ tool }),
 
-				code: defaultCode,
-				setCode: code => set({ code }),
+					code: defaultCode,
+					setCode: code => set({ code }),
 
-				language: "javascript",
-				setLanguage: language => set({ language }),
+					language: "javascript",
+					setLanguage: language => set({ language }),
 
-				jsOptions: defaultJsOptions,
-				setJsOptions: jsOptions => set({ jsOptions }),
+					jsOptions: defaultJsOptions,
+					setJsOptions: jsOptions => set({ jsOptions }),
 
-				jsonOptions: defaultJsonOptions,
-				setJsonOptions: jsonOptions => set({ jsonOptions }),
+					jsonOptions: defaultJsonOptions,
+					setJsonOptions: jsonOptions => set({ jsonOptions }),
 
-				cssOptions: defaultCssOptions,
-				setCssOptions: cssOptions => set({ cssOptions }),
+					cssOptions: defaultCssOptions,
+					setCssOptions: cssOptions => set({ cssOptions }),
 
-				markdownOptions: defaultMarkdownOptions,
-				setMarkdownOptions: markdownOptions => set({ markdownOptions }),
+					markdownOptions: defaultMarkdownOptions,
+					setMarkdownOptions: markdownOptions =>
+						set({ markdownOptions }),
 
-				wrap: true,
-				setWrap: wrap => set({ wrap }),
+					wrap: true,
+					setWrap: wrap => set({ wrap }),
 
-				viewModes: defaultViewModes,
-				setViewModes: viewModes => set({ viewModes }),
+					viewModes: defaultViewModes,
+					setViewModes: viewModes => set({ viewModes }),
 
-				pathIndex: defaultPathIndex,
-				setPathIndex: pathIndex => set({ pathIndex }),
+					pathIndex: defaultPathIndex,
+					setPathIndex: pathIndex => set({ pathIndex }),
 
-				esquerySelector: {
-					selector: "",
+					esquerySelector: {
+						selector: "",
+					},
+					setEsquerySelector: esquerySelector =>
+						set({ esquerySelector }),
+				}),
+				{
+					name: "eslint-explorer",
+					storage: createJSONStorage(() => hashStorage),
 				},
-				setEsquerySelector: esquerySelector => set({ esquerySelector }),
-			}),
+			),
 			{
 				name: "eslint-explorer",
-				storage: createJSONStorage(() => hashStorage),
-
 				onRehydrateStorage: () => state => {
 					if (!state) return;
 
@@ -193,8 +197,5 @@ export const useExplorer = create<ExplorerState>()(
 				},
 			},
 		),
-		{
-			name: "eslint-explorer",
-		},
 	),
 );


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

-   [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request?

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)
Use the `onRehydrateStorage` hook to add any new field if it is missing in the store. 


The previous implementation - https://github.com/eslint/code-explorer/pull/97, where we checked for missing language code, works fine in cases where a user manually selects a new language from the dropdown. In this scenario, if the corresponding code entry was missing, we could dynamically patch it on the fly.

However, this approach breaks when a user opens a shared link that points directly to a newly added language. Since the state is rehydrated from the URL hash and doesn’t include the new language (because it wasn’t present in the original persisted state), the app can break.

We’re now using the onRehydrateStorage hook provided by Zustand. This hook ensures that immediately after the state is loaded from storage, any missing fields (like code for a new language) are automatically added using defaultCode. This centralises the patching logic inside the store (use-explorer file), ensures the state is always complete, and prevents issues with incomplete or outdated persisted data.

Also, all code logic related to state hydration and defaults stays cleanly inside the Zustand store.

#### Related Issues

#### Is there anything you'd like reviewers to focus on?

<!-- markdownlint-disable-file MD004 -->
