### PR TITLE
refactor: add missing type to `JavaScriptPanel`

### DIFF
--- a/src/components/options.tsx
+++ b/src/components/options.tsx
@@ -124,7 +124,7 @@ const CssPanel: React.FC = () => {
 	);
 };
 
-const JavaScriptPanel = () => {
+const JavaScriptPanel: React.FC = () => {
 	const explorer = useExplorer();
 	const { jsOptions, setJsOptions } = explorer;
 	const { parser, sourceType, esVersion, isJSX } = jsOptions;


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

-   [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request?

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

Hello,

While reviewing https://github.com/eslint/code-explorer/pull/99, I noticed that the `JavaScriptPanel` component is missing a type.

Other panels like `CssPanel` are using this type correctly.

#### Related Issues

#### Is there anything you'd like reviewers to focus on?

<!-- markdownlint-disable-file MD004 -->
