### PR TITLE
feat: change ESQuery Selector placeholder text based on language

### DIFF
--- a/src/components/esquery-selector-input.tsx
+++ b/src/components/esquery-selector-input.tsx
@@ -1,24 +1,10 @@
 import { useId, type FC } from "react";
 import { Label } from "@/components/ui/label";
 import { TextField } from "@/components/ui/text-field";
-import { useExplorer, type Language } from "@/hooks/use-explorer";
+import { useExplorer } from "@/hooks/use-explorer";
 import { useAST } from "@/hooks/use-ast";
 import { cn } from "@/lib/utils";
-
-const esquerySelectorPlaceholder = (language: Language) => {
-	switch (language) {
-		case "javascript":
-			return 'e.g. "ImportDeclaration > Literal"';
-		case "json":
-			return 'e.g. "Member > String"';
-		case "markdown":
-			return 'e.g. "Heading > Text"';
-		case "css":
-			return 'e.g. "Block > Declaration"';
-		case "html":
-			return 'e.g. "Document > Doctype"';
-	}
-};
+import { esquerySelectorPlaceholder } from "@/lib/const";
 
 export const EsquerySelectorInput: FC = () => {
 	const { esquerySelector, setEsquerySelector, language } = useExplorer();
@@ -36,7 +22,7 @@ export const EsquerySelectorInput: FC = () => {
 			</Label>
 			<TextField
 				id={htmlId}
-				placeholder={esquerySelectorPlaceholder(language)}
+				placeholder={esquerySelectorPlaceholder[language]}
 				className={cn(
 					"flex-1",
 					!astParseResult.ok ||

--- a/src/components/esquery-selector-input.tsx
+++ b/src/components/esquery-selector-input.tsx
@@ -1,12 +1,27 @@
 import { useId, type FC } from "react";
 import { Label } from "@/components/ui/label";
 import { TextField } from "@/components/ui/text-field";
-import { useExplorer } from "@/hooks/use-explorer";
+import { useExplorer, type Language } from "@/hooks/use-explorer";
 import { useAST } from "@/hooks/use-ast";
 import { cn } from "@/lib/utils";
 
+const esquerySelectorPlaceholder = (language: Language) => {
+	switch (language) {
+		case "javascript":
+			return 'e.g. "ImportDeclaration > Literal"';
+		case "json":
+			return 'e.g. "Member > String"';
+		case "markdown":
+			return 'e.g. "Heading > Text"';
+		case "css":
+			return 'e.g. "Block > Declaration"';
+		case "html":
+			return 'e.g. "Document > Doctype"';
+	}
+};
+
 export const EsquerySelectorInput: FC = () => {
-	const { esquerySelector, setEsquerySelector } = useExplorer();
+	const { esquerySelector, setEsquerySelector, language } = useExplorer();
 	const astParseResult = useAST();
 	const htmlId = useId();
 
@@ -21,7 +36,7 @@ export const EsquerySelectorInput: FC = () => {
 			</Label>
 			<TextField
 				id={htmlId}
-				placeholder={'e.g. "ImportDeclaration > Literal"'}
+				placeholder={esquerySelectorPlaceholder(language)}
 				className={cn(
 					"flex-1",
 					!astParseResult.ok ||

--- a/src/lib/const.ts
+++ b/src/lib/const.ts
@@ -256,6 +256,14 @@ export const pathViewOptions = [
 	},
 ];
 
+export const esquerySelectorPlaceholder = {
+	javascript: 'e.g. "ImportDeclaration > Literal"',
+	json: 'e.g. "Member > String"',
+	markdown: 'e.g. "Heading > Text"',
+	css: 'e.g. "Block > Declaration"',
+	html: 'e.g. "Document > Doctype"',
+};
+
 export const defaultJsCode = `
 /**
  * Type or paste some JavaScript here to learn more about


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

-   [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request?

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

Hello,

Currently, the ESQuery Selector's placeholder remains the same even when switching to a language other than JavaScript.

To improve this, I added support for updating the ESQuery Selector placeholder based on the selected language.

Now, the placeholders correctly reflect language-specific examples!

- Before: The placeholder always showed `e.g. "ImportDeclaration > Literal"` regardless of the language

![image](https://github.com/user-attachments/assets/1a08e447-c498-4178-bd41-a1045f185dff)

- After:  The placeholder now varies depending on the selected language

![image](https://github.com/user-attachments/assets/71b81faf-ce57-4754-b451-5a73e509421b)

![image](https://github.com/user-attachments/assets/b31ac906-5b69-4cbf-b9a6-ec17fbac6c93)

![image](https://github.com/user-attachments/assets/4d6aa17a-4bd4-4064-8df5-f4a32c8ee8de)

![image](https://github.com/user-attachments/assets/940fe8a7-965e-4404-b15a-ab9e44e85264)

![image](https://github.com/user-attachments/assets/098fb4d2-a339-4188-bf18-aac0b1fc0b05)

#### Related Issues

#### Is there anything you'd like reviewers to focus on?

<!-- markdownlint-disable-file MD004 -->
