### PR TITLE
feat: expose HTML language options in options panel

### DIFF
--- a/src/components/options.tsx
+++ b/src/components/options.tsx
@@ -15,6 +15,7 @@ import {
 	parsers,
 	sourceTypes,
 	versions,
+	templateEngineSyntaxes,
 } from "@/lib/const";
 import { Button } from "./ui/button";
 import { Label } from "./ui/label";
@@ -28,6 +29,7 @@ import type {
 	MarkdownFrontmatter,
 	SourceType,
 	Version,
+	TemplateEngineSyntax,
 } from "@/hooks/use-explorer";
 
 const JSONPanel: React.FC = () => {
@@ -181,7 +183,38 @@ const JavaScriptPanel: React.FC = () => {
 };
 
 const HTMLPanel: React.FC = () => {
-	return <></>;
+	const explorer = useExplorer();
+	const { htmlOptions, setHtmlOptions } = explorer;
+	const { templateEngineSyntax, frontmatter } = htmlOptions;
+
+	return (
+		<>
+			<LabeledSelect
+				id="templateEngineSyntax"
+				label="Template Engine Syntax"
+				value={templateEngineSyntax}
+				onValueChange={(value: string) => {
+					const templateEngineSyntax = value as TemplateEngineSyntax;
+					setHtmlOptions({
+						...htmlOptions,
+						templateEngineSyntax,
+					});
+				}}
+				items={templateEngineSyntaxes}
+				placeholder="Template Engine Syntax"
+			/>
+			<div className="flex items-center gap-1.5">
+				<Switch
+					id="htmlFrontmatter"
+					checked={frontmatter}
+					onCheckedChange={(value: boolean) => {
+						setHtmlOptions({ ...htmlOptions, frontmatter: value });
+					}}
+				/>
+				<Label htmlFor="htmlFrontmatter">Front Matter</Label>
+			</div>
+		</>
+	);
 };
 
 const Panel = ({ language }: { language: string }) => {

--- a/src/hooks/use-ast.ts
+++ b/src/hooks/use-ast.ts
@@ -7,6 +7,7 @@ import html from "@html-eslint/eslint-plugin";
 import esquery from "esquery";
 import { useExplorer } from "@/hooks/use-explorer";
 import { assertIsUnreachable } from "@/lib/utils";
+import { templateEngineSyntaxPresets } from "@/lib/const";
 
 export function useAST() {
 	const {
@@ -16,6 +17,7 @@ export function useAST() {
 		cssOptions,
 		jsonOptions,
 		markdownOptions,
+		htmlOptions,
 		esquerySelector,
 	} = useExplorer();
 
@@ -88,13 +90,23 @@ export function useAST() {
 		}
 
 		case "html": {
+			const { templateEngineSyntax, frontmatter } = htmlOptions;
 			const language = html.languages.html;
-			astParseResult = language.parse({
-				body: code.html,
-				path: "",
-				physicalPath: "",
-				bom: false,
-			});
+			astParseResult = language.parse(
+				{
+					body: code.html,
+					path: "",
+					physicalPath: "",
+					bom: false,
+				},
+				{
+					languageOptions: {
+						templateEngineSyntax:
+							templateEngineSyntaxPresets[templateEngineSyntax],
+						frontmatter,
+					},
+				},
+			);
 			break;
 		}
 

--- a/src/hooks/use-explorer.ts
+++ b/src/hooks/use-explorer.ts
@@ -12,6 +12,7 @@ import {
 	defaultJsonOptions,
 	defaultMarkdownOptions,
 	defaultCssOptions,
+	defaultHtmlOptions,
 	defaultPathIndex,
 	defaultViewModes,
 } from "../lib/const";
@@ -23,6 +24,7 @@ export type JsonMode = "json" | "jsonc" | "json5";
 export type MarkdownMode = "commonmark" | "gfm";
 export type MarkdownFrontmatter = "off" | "yaml" | "toml" | "json";
 export type CssMode = "css";
+export type TemplateEngineSyntax = "none" | "handlebars" | "twig" | "erb";
 
 export type Code = {
 	javascript: string;
@@ -51,6 +53,11 @@ export type MarkdownOptions = {
 export type CssOptions = {
 	cssMode: CssMode;
 	tolerant: boolean;
+};
+
+export type HtmlOptions = {
+	templateEngineSyntax: TemplateEngineSyntax;
+	frontmatter: boolean;
 };
 
 export type PathIndex = {
@@ -89,6 +96,9 @@ type ExplorerState = {
 
 	cssOptions: CssOptions;
 	setCssOptions: (cssOptions: CssOptions) => void;
+
+	htmlOptions: HtmlOptions;
+	setHtmlOptions: (htmlOptions: HtmlOptions) => void;
 
 	wrap: boolean;
 	setWrap: (wrap: boolean) => void;
@@ -151,6 +161,9 @@ export const useExplorer = create<ExplorerState>()(
 					markdownOptions: defaultMarkdownOptions,
 					setMarkdownOptions: markdownOptions =>
 						set({ markdownOptions }),
+
+					htmlOptions: defaultHtmlOptions,
+					setHtmlOptions: htmlOptions => set({ htmlOptions }),
 
 					wrap: true,
 					setWrap: wrap => set({ wrap }),

--- a/src/lib/const.ts
+++ b/src/lib/const.ts
@@ -12,6 +12,7 @@ import type {
 	JsonOptions,
 	MarkdownOptions,
 	CssOptions,
+	HtmlOptions,
 	PathIndex,
 	ViewModes,
 	Code,
@@ -220,6 +221,32 @@ export const cssModes = [
 		label: "CSS",
 	},
 ];
+
+export const templateEngineSyntaxes = [
+	{
+		value: "none",
+		label: "None",
+	},
+	{
+		value: "handlebars",
+		label: "Handlebars",
+	},
+	{
+		value: "twig",
+		label: "Twig",
+	},
+	{
+		value: "erb",
+		label: "ERB",
+	},
+];
+
+export const templateEngineSyntaxPresets = {
+	none: {},
+	handlebars: { "{{": "}}" },
+	twig: { "{{": "}}", "{%": "%}", "{#": "#}" },
+	erb: { "<%": "%>" },
+};
 
 export const astViewOptions = [
 	{
@@ -445,6 +472,11 @@ export const defaultMarkdownOptions: MarkdownOptions = {
 export const defaultCssOptions: CssOptions = {
 	cssMode: "css",
 	tolerant: false,
+};
+
+export const defaultHtmlOptions: HtmlOptions = {
+	templateEngineSyntax: "none",
+	frontmatter: false,
 };
 
 export const defaultPathIndex: PathIndex = {


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request?

This PR exposes the HTML language options (`templateEngineSyntax` and `frontmatter`) in the options panel, allowing users to configure these settings directly from the UI.

#### What changes did you make? (Give an overview)

- Added UI controls to the options panel for the HTML language.
- Users can now select a templateEngineSyntax preset from a dropdown.
- Users can configure the frontmatter option for HTML files.

#### Related Issues

Fixes #117

#### Is there anything you'd like reviewers to focus on?

<!-- markdownlint-disable-file MD004 -->
