### PR TITLE
fix: set espree `range: true` to fix scope crash

### DIFF
--- a/src/hooks/use-ast.ts
+++ b/src/hooks/use-ast.ts
@@ -29,6 +29,7 @@ export function useAST() {
 		case "javascript": {
 			try {
 				const ast = espree.parse(code.javascript, {
+					range: true,
 					// @ts-expect-error mismatch between the latest release of `espree` and `@types/espree`.
 					ecmaVersion: jsOptions.esVersion,
 					sourceType: jsOptions.sourceType,


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/.github/blob/master/CONTRIBUTING.md).

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Update or create tests
    - If performance-related, include a benchmark
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What is the purpose of this pull request?

Fix a crash in the scope analyzer caused by missing `node.range` on nodes when parsing JavaScript.

The scope analyzer relies on `node.range` to be present. In particular, `FunctionScope.__isValidResolution` reads `this.block.body.range[0]` and `d.name.range[0]`. Espree’s default is `range: false`, so without enabling it, `node.range` is undefined, and accessing `[0]` throws `Cannot read properties of undefined (reading '0')`.

Note: As a side effect of enabling `range: true`, the AST Tree view now displays a range property on each node.

#### What changes did you make? (Give an overview)

Set `range: true` in `espree.parse` so nodes include the `range` property required by the scope analyzer.

#### Related Issues

Fixes #125

<!-- include tags like "fixes #123" or "refs #123" -->

#### Is there anything you'd like reviewers to focus on?
