### PR TITLE
fix: prevent overlay flicker during drag-and-drop

### DIFF
--- a/src/components/ast/ast-view-mode.tsx
+++ b/src/components/ast/ast-view-mode.tsx
@@ -3,7 +3,7 @@
 import { useExplorer } from "@/hooks/use-explorer";
 import { ToggleGroup, ToggleGroupItem } from "@/components/ui/toggle-group";
 import { astViewOptions } from "@/lib/const";
-import { cn } from "@/lib/utils";
+import { mergeClassNames } from "@/lib/utils";
 import type { FC } from "react";
 
 export const AstViewMode: FC = () => {
@@ -29,7 +29,7 @@ export const AstViewMode: FC = () => {
 				<ToggleGroupItem
 					key={option.value}
 					value={option.value}
-					className={cn(
+					className={mergeClassNames(
 						"border -m-px flex items-center gap-1.5",
 						option.value === astView
 							? "!bg-background"

--- a/src/components/ast/css-ast-tree-item.tsx
+++ b/src/components/ast/css-ast-tree-item.tsx
@@ -5,7 +5,7 @@ import {
 } from "@/components/ui/accordion";
 import { TreeEntry } from "../tree-entry";
 import type { FC } from "react";
-import { cn } from "@/lib/utils";
+import { mergeClassNames } from "@/lib/utils";
 
 type ASTNode = {
 	readonly type: string;
@@ -28,7 +28,7 @@ export const CssAstTreeItem: FC<CssAstTreeItemProperties> = ({
 	return (
 		<AccordionItem
 			value={`${index}-${data.type}`}
-			className={cn(
+			className={mergeClassNames(
 				"border border-card rounded-lg overflow-hidden",
 				isEsqueryMatchedNode && "border-primary border-4",
 			)}

--- a/src/components/ast/html-ast-tree-item.tsx
+++ b/src/components/ast/html-ast-tree-item.tsx
@@ -5,7 +5,7 @@ import {
 } from "@/components/ui/accordion";
 import { TreeEntry } from "../tree-entry";
 import type { FC } from "react";
-import { cn } from "@/lib/utils";
+import { mergeClassNames } from "@/lib/utils";
 
 type ASTNode = {
 	readonly type: string;
@@ -28,7 +28,7 @@ export const HtmlAstTreeItem: FC<HtmlAstTreeItemProperties> = ({
 	return (
 		<AccordionItem
 			value={`${index}-${data.type}`}
-			className={cn(
+			className={mergeClassNames(
 				"border border-card rounded-lg overflow-hidden",
 				isEsqueryMatchedNode && "border-primary border-4",
 			)}

--- a/src/components/ast/javascript-ast-tree-item.tsx
+++ b/src/components/ast/javascript-ast-tree-item.tsx
@@ -6,7 +6,7 @@ import {
 import { TreeEntry } from "../tree-entry";
 import type { FC } from "react";
 import type * as espree from "espree";
-import { cn } from "@/lib/utils";
+import { mergeClassNames } from "@/lib/utils";
 
 export type JavascriptAstTreeItemProperties = {
 	readonly index: number;
@@ -26,7 +26,7 @@ export const JavascriptAstTreeItem: FC<JavascriptAstTreeItemProperties> = ({
 	return (
 		<AccordionItem
 			value={`${index}-${data.type}`}
-			className={cn(
+			className={mergeClassNames(
 				"border border-card rounded-lg overflow-hidden",
 				isEsqueryMatchedNode && "border-primary border-4",
 			)}

--- a/src/components/ast/json-ast-tree-item.tsx
+++ b/src/components/ast/json-ast-tree-item.tsx
@@ -5,7 +5,7 @@ import {
 } from "@/components/ui/accordion";
 import { TreeEntry } from "../tree-entry";
 import type { FC } from "react";
-import { cn } from "@/lib/utils";
+import { mergeClassNames } from "@/lib/utils";
 
 type ASTNode = {
 	readonly type: string;
@@ -28,7 +28,7 @@ export const JsonAstTreeItem: FC<JsonAstTreeItemProperties> = ({
 	return (
 		<AccordionItem
 			value={`${index}-${data.type}`}
-			className={cn(
+			className={mergeClassNames(
 				"border border-card rounded-lg overflow-hidden",
 				isEsqueryMatchedNode && "border-primary border-4",
 			)}

--- a/src/components/ast/markdown-ast-tree-item.tsx
+++ b/src/components/ast/markdown-ast-tree-item.tsx
@@ -5,7 +5,7 @@ import {
 } from "@/components/ui/accordion";
 import { TreeEntry } from "../tree-entry";
 import type { FC } from "react";
-import { cn } from "@/lib/utils";
+import { mergeClassNames } from "@/lib/utils";
 
 type ASTNode = {
 	readonly type: string;
@@ -28,7 +28,7 @@ export const MarkdownAstTreeItem: FC<MarkdownAstTreeItemProperties> = ({
 	return (
 		<AccordionItem
 			value={`${index}-${data.type}`}
-			className={cn(
+			className={mergeClassNames(
 				"border border-card rounded-lg overflow-hidden",
 				isEsqueryMatchedNode && "border-primary border-4",
 			)}

--- a/src/components/editor.tsx
+++ b/src/components/editor.tsx
@@ -10,7 +10,7 @@ import { css } from "@codemirror/lang-css";
 import { html } from "@codemirror/lang-html";
 import { EditorView } from "@codemirror/view";
 import { LanguageSupport } from "@codemirror/language";
-import { cn, debounce } from "@/lib/utils";
+import { mergeClassNames, debounce } from "@/lib/utils";
 import {
 	ESLintPlaygroundTheme,
 	ESLintPlaygroundHighlightStyle,
@@ -152,12 +152,12 @@ export const Editor: FC<EditorProperties> = ({
 		};
 	}, [onChange, readOnly]);
 
-	const editorClasses = cn("relative", {
+	const editorClasses = mergeClassNames("relative", {
 		"h-[calc(100%-72px)]": readOnly,
 		"h-[calc(100%-57px)]": !readOnly,
 	});
 
-	const dropAreaClass = cn(
+	const dropAreaClass = mergeClassNames(
 		"absolute inset-0 z-10 pointer-events-none flex items-center justify-center transition-opacity duration-150 bg-dropContainer",
 		{
 			"opacity-0": !isDragOver,

--- a/src/components/esquery-selector-input.tsx
+++ b/src/components/esquery-selector-input.tsx
@@ -3,7 +3,7 @@ import { Label } from "@/components/ui/label";
 import { TextField } from "@/components/ui/text-field";
 import { useExplorer } from "@/hooks/use-explorer";
 import { useAST } from "@/hooks/use-ast";
-import { cn } from "@/lib/utils";
+import { mergeClassNames } from "@/lib/utils";
 import { esquerySelectorPlaceholder } from "@/lib/const";
 
 export const EsquerySelectorInput: FC = () => {
@@ -23,7 +23,7 @@ export const EsquerySelectorInput: FC = () => {
 			<TextField
 				id={htmlId}
 				placeholder={esquerySelectorPlaceholder[language]}
-				className={cn(
+				className={mergeClassNames(
 					"flex-1",
 					!astParseResult.ok ||
 						(highlightAsNotMatching &&

--- a/src/components/path/path-view-mode.tsx
+++ b/src/components/path/path-view-mode.tsx
@@ -3,7 +3,7 @@
 import { useExplorer } from "@/hooks/use-explorer";
 import { ToggleGroup, ToggleGroupItem } from "@/components/ui/toggle-group";
 import { pathViewOptions } from "@/lib/const";
-import { cn } from "@/lib/utils";
+import { mergeClassNames } from "@/lib/utils";
 import type { FC } from "react";
 
 export const PathViewMode: FC = () => {
@@ -30,7 +30,7 @@ export const PathViewMode: FC = () => {
 				<ToggleGroupItem
 					key={option.value}
 					value={option.value}
-					className={cn(
+					className={mergeClassNames(
 						"border -m-px flex items-center gap-1.5",
 						option.value === pathView
 							? "!bg-background"

--- a/src/components/scope/scope-item.tsx
+++ b/src/components/scope/scope-item.tsx
@@ -6,7 +6,7 @@ import {
 } from "@/components/ui/accordion";
 import { TreeEntry } from "../tree-entry";
 import type { FC } from "react";
-import { cn } from "@/lib/utils";
+import { mergeClassNames } from "@/lib/utils";
 
 type ScopeItemProperties = {
 	isArray: boolean;
@@ -50,7 +50,7 @@ export const ScopeItem: FC<ScopeItemProperties> = ({
 		return (
 			<AccordionItem
 				value={path + "." + index + "." + key}
-				className={cn(
+				className={mergeClassNames(
 					"border border-card rounded-lg overflow-hidden",
 					isEsqueryMatchedNode && "border-primary border-4",
 				)}
@@ -76,7 +76,7 @@ export const ScopeItem: FC<ScopeItemProperties> = ({
 
 	return (
 		<div
-			className={cn(
+			className={mergeClassNames(
 				"border border-card rounded-lg overflow-hidden",
 				isEsqueryMatchedNode && "border-primary border-4",
 			)}

--- a/src/components/scope/scope-view-mode.tsx
+++ b/src/components/scope/scope-view-mode.tsx
@@ -3,7 +3,7 @@
 import { useExplorer } from "@/hooks/use-explorer";
 import { ToggleGroup, ToggleGroupItem } from "@/components/ui/toggle-group";
 import { scopeViewOptions } from "@/lib/const";
-import { cn } from "@/lib/utils";
+import { mergeClassNames } from "@/lib/utils";
 import type { FC } from "react";
 
 export const ScopeViewMode: FC = () => {
@@ -30,7 +30,7 @@ export const ScopeViewMode: FC = () => {
 				<ToggleGroupItem
 					key={option.value}
 					value={option.value}
-					className={cn(
+					className={mergeClassNames(
 						"border border-card -m-px flex items-center gap-1.5",
 						option.value === scopeView
 							? "!bg-background"

--- a/src/components/ui/accordion.tsx
+++ b/src/components/ui/accordion.tsx
@@ -4,7 +4,7 @@ import * as React from "react";
 import * as AccordionPrimitive from "@radix-ui/react-accordion";
 import { ChevronDown } from "lucide-react";
 
-import { cn } from "@/lib/utils";
+import { mergeClassNames } from "@/lib/utils";
 
 const Accordion = AccordionPrimitive.Root;
 
@@ -15,7 +15,7 @@ const AccordionItem = ({
 }: React.ComponentPropsWithRef<typeof AccordionPrimitive.Item>) => (
 	<AccordionPrimitive.Item
 		ref={ref}
-		className={cn("border-b", className)}
+		className={mergeClassNames("border-b", className)}
 		{...props}
 	/>
 );
@@ -29,7 +29,7 @@ const AccordionTrigger = ({
 	<AccordionPrimitive.Header className="flex">
 		<AccordionPrimitive.Trigger
 			ref={ref}
-			className={cn(
+			className={mergeClassNames(
 				"flex flex-1 items-center justify-between py-4 font-medium transition-all hover:underline [&[data-state=open]>svg]:rotate-180",
 				className,
 			)}
@@ -52,7 +52,9 @@ const AccordionContent = ({
 		className="overflow-hidden text-sm transition-all data-[state=closed]:animate-accordion-up data-[state=open]:animate-accordion-down"
 		{...props}
 	>
-		<div className={cn("pb-4 pt-0", className)}>{children}</div>
+		<div className={mergeClassNames("pb-4 pt-0", className)}>
+			{children}
+		</div>
 	</AccordionPrimitive.Content>
 );
 

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -2,7 +2,7 @@ import * as React from "react";
 import { Slot } from "@radix-ui/react-slot";
 import { cva, type VariantProps } from "class-variance-authority";
 
-import { cn } from "@/lib/utils";
+import { mergeClassNames } from "@/lib/utils";
 
 const buttonVariants = cva(
 	"inline-flex items-center justify-center whitespace-nowrap rounded-md text-sm font-medium ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50",
@@ -52,7 +52,9 @@ const Button = ({
 	const Comp = asChild ? Slot : "button";
 	return (
 		<Comp
-			className={cn(buttonVariants({ variant, size, className }))}
+			className={mergeClassNames(
+				buttonVariants({ variant, size, className }),
+			)}
 			ref={ref}
 			{...props}
 		/>

--- a/src/components/ui/dialog.tsx
+++ b/src/components/ui/dialog.tsx
@@ -4,7 +4,7 @@ import * as React from "react";
 import * as DialogPrimitive from "@radix-ui/react-dialog";
 import { X } from "lucide-react";
 
-import { cn } from "@/lib/utils";
+import { mergeClassNames } from "@/lib/utils";
 
 const Dialog = DialogPrimitive.Root;
 
@@ -21,7 +21,7 @@ const DialogOverlay = ({
 }: React.ComponentPropsWithRef<typeof DialogPrimitive.Overlay>) => (
 	<DialogPrimitive.Overlay
 		ref={ref}
-		className={cn(
+		className={mergeClassNames(
 			"fixed inset-0 z-50 bg-black/80  data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
 			className,
 		)}
@@ -39,7 +39,7 @@ const DialogContent = ({
 		<DialogOverlay />
 		<DialogPrimitive.Content
 			ref={ref}
-			className={cn(
+			className={mergeClassNames(
 				"fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg",
 				className,
 			)}
@@ -59,7 +59,7 @@ const DialogHeader = ({
 	...props
 }: React.HTMLAttributes<HTMLDivElement>) => (
 	<div
-		className={cn(
+		className={mergeClassNames(
 			"flex flex-col space-y-1.5 text-center sm:text-left",
 			className,
 		)}
@@ -72,7 +72,7 @@ const DialogFooter = ({
 	...props
 }: React.HTMLAttributes<HTMLDivElement>) => (
 	<div
-		className={cn(
+		className={mergeClassNames(
 			"flex flex-col-reverse sm:flex-row sm:justify-end sm:space-x-2",
 			className,
 		)}
@@ -87,7 +87,7 @@ const DialogTitle = ({
 }: React.ComponentPropsWithRef<typeof DialogPrimitive.Title>) => (
 	<DialogPrimitive.Title
 		ref={ref}
-		className={cn(
+		className={mergeClassNames(
 			"text-lg font-semibold leading-none tracking-tight",
 			className,
 		)}
@@ -102,7 +102,7 @@ const DialogDescription = ({
 }: React.ComponentPropsWithRef<typeof DialogPrimitive.Description>) => (
 	<DialogPrimitive.Description
 		ref={ref}
-		className={cn("text-sm text-muted-foreground", className)}
+		className={mergeClassNames("text-sm text-muted-foreground", className)}
 		{...props}
 	/>
 );

--- a/src/components/ui/dropdown-menu.tsx
+++ b/src/components/ui/dropdown-menu.tsx
@@ -4,7 +4,7 @@ import * as React from "react";
 import * as DropdownMenuPrimitive from "@radix-ui/react-dropdown-menu";
 import { Check, ChevronRight, Circle } from "lucide-react";
 
-import { cn } from "@/lib/utils";
+import { mergeClassNames } from "@/lib/utils";
 
 const DropdownMenu = DropdownMenuPrimitive.Root;
 
@@ -29,7 +29,7 @@ const DropdownMenuSubTrigger = ({
 }) => (
 	<DropdownMenuPrimitive.SubTrigger
 		ref={ref}
-		className={cn(
+		className={mergeClassNames(
 			"flex cursor-default select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none focus:bg-accent data-[state=open]:bg-accent",
 			inset && "pl-8",
 			className,
@@ -48,7 +48,7 @@ const DropdownMenuSubContent = ({
 }: React.ComponentPropsWithRef<typeof DropdownMenuPrimitive.SubContent>) => (
 	<DropdownMenuPrimitive.SubContent
 		ref={ref}
-		className={cn(
+		className={mergeClassNames(
 			"z-50 min-w-[8rem] overflow-hidden rounded-md border bg-popover p-1 text-popover-foreground shadow-lg data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
 			className,
 		)}
@@ -66,7 +66,7 @@ const DropdownMenuContent = ({
 		<DropdownMenuPrimitive.Content
 			ref={ref}
 			sideOffset={sideOffset}
-			className={cn(
+			className={mergeClassNames(
 				"z-50 min-w-[8rem] overflow-hidden rounded-md border bg-popover p-1 text-popover-foreground shadow-md data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
 				className,
 			)}
@@ -85,7 +85,7 @@ const DropdownMenuItem = ({
 }) => (
 	<DropdownMenuPrimitive.Item
 		ref={ref}
-		className={cn(
+		className={mergeClassNames(
 			"relative flex cursor-default select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none transition-colors focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
 			inset && "pl-8",
 			className,
@@ -103,7 +103,7 @@ const DropdownMenuCheckboxItem = ({
 }: React.ComponentPropsWithRef<typeof DropdownMenuPrimitive.CheckboxItem>) => (
 	<DropdownMenuPrimitive.CheckboxItem
 		ref={ref}
-		className={cn(
+		className={mergeClassNames(
 			"relative flex cursor-default select-none items-center rounded-sm py-1.5 pl-8 pr-2 text-sm outline-none transition-colors focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
 			className,
 		)}
@@ -127,7 +127,7 @@ const DropdownMenuRadioItem = ({
 }: React.ComponentPropsWithRef<typeof DropdownMenuPrimitive.RadioItem>) => (
 	<DropdownMenuPrimitive.RadioItem
 		ref={ref}
-		className={cn(
+		className={mergeClassNames(
 			"relative flex cursor-default select-none items-center rounded-sm py-1.5 pl-8 pr-2 text-sm outline-none transition-colors focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
 			className,
 		)}
@@ -152,7 +152,7 @@ const DropdownMenuLabel = ({
 }) => (
 	<DropdownMenuPrimitive.Label
 		ref={ref}
-		className={cn(
+		className={mergeClassNames(
 			"px-2 py-1.5 text-sm font-semibold",
 			inset && "pl-8",
 			className,
@@ -168,7 +168,7 @@ const DropdownMenuSeparator = ({
 }: React.ComponentPropsWithRef<typeof DropdownMenuPrimitive.Separator>) => (
 	<DropdownMenuPrimitive.Separator
 		ref={ref}
-		className={cn("-mx-1 my-1 h-px bg-muted", className)}
+		className={mergeClassNames("-mx-1 my-1 h-px bg-muted", className)}
 		{...props}
 	/>
 );
@@ -179,7 +179,7 @@ const DropdownMenuShortcut = ({
 }: React.HTMLAttributes<HTMLSpanElement>) => {
 	return (
 		<span
-			className={cn(
+			className={mergeClassNames(
 				"ml-auto text-xs tracking-widest opacity-60",
 				className,
 			)}

--- a/src/components/ui/label.tsx
+++ b/src/components/ui/label.tsx
@@ -4,7 +4,7 @@ import * as React from "react";
 import * as LabelPrimitive from "@radix-ui/react-label";
 import { cva, type VariantProps } from "class-variance-authority";
 
-import { cn } from "@/lib/utils";
+import { mergeClassNames } from "@/lib/utils";
 
 const labelVariants = cva(
 	"text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70",
@@ -18,7 +18,7 @@ const Label = ({
 	VariantProps<typeof labelVariants>) => (
 	<LabelPrimitive.Root
 		ref={ref}
-		className={cn(labelVariants(), className)}
+		className={mergeClassNames(labelVariants(), className)}
 		{...props}
 	/>
 );

--- a/src/components/ui/popover.tsx
+++ b/src/components/ui/popover.tsx
@@ -3,7 +3,7 @@
 import * as React from "react";
 import * as PopoverPrimitive from "@radix-ui/react-popover";
 
-import { cn } from "@/lib/utils";
+import { mergeClassNames } from "@/lib/utils";
 
 const Popover = PopoverPrimitive.Root;
 
@@ -21,7 +21,7 @@ const PopoverContent = ({
 			ref={ref}
 			align={align}
 			sideOffset={sideOffset}
-			className={cn(
+			className={mergeClassNames(
 				"z-50 w-72 rounded-md border border-card bg-popover p-4 text-popover-foreground shadow-md outline-none data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
 				className,
 			)}

--- a/src/components/ui/select.tsx
+++ b/src/components/ui/select.tsx
@@ -4,7 +4,7 @@ import * as React from "react";
 import * as SelectPrimitive from "@radix-ui/react-select";
 import { Check, ChevronDown, ChevronUp } from "lucide-react";
 
-import { cn } from "@/lib/utils";
+import { mergeClassNames } from "@/lib/utils";
 
 const Select = SelectPrimitive.Root;
 
@@ -20,7 +20,7 @@ const SelectTrigger = ({
 }: React.ComponentPropsWithRef<typeof SelectPrimitive.Trigger>) => (
 	<SelectPrimitive.Trigger
 		ref={ref}
-		className={cn(
+		className={mergeClassNames(
 			"flex h-10 w-full items-center justify-between rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 [&>span]:line-clamp-1",
 			className,
 		)}
@@ -40,7 +40,7 @@ const SelectScrollUpButton = ({
 }: React.ComponentPropsWithRef<typeof SelectPrimitive.ScrollUpButton>) => (
 	<SelectPrimitive.ScrollUpButton
 		ref={ref}
-		className={cn(
+		className={mergeClassNames(
 			"flex cursor-default items-center justify-center py-1",
 			className,
 		)}
@@ -57,7 +57,7 @@ const SelectScrollDownButton = ({
 }: React.ComponentPropsWithRef<typeof SelectPrimitive.ScrollDownButton>) => (
 	<SelectPrimitive.ScrollDownButton
 		ref={ref}
-		className={cn(
+		className={mergeClassNames(
 			"flex cursor-default items-center justify-center py-1",
 			className,
 		)}
@@ -77,7 +77,7 @@ const SelectContent = ({
 	<SelectPrimitive.Portal>
 		<SelectPrimitive.Content
 			ref={ref}
-			className={cn(
+			className={mergeClassNames(
 				"relative z-50 max-h-96 min-w-[8rem] overflow-hidden rounded-md border bg-popover text-popover-foreground shadow-md data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
 				position === "popper" &&
 					"data-[side=bottom]:translate-y-1 data-[side=left]:-translate-x-1 data-[side=right]:translate-x-1 data-[side=top]:-translate-y-1",
@@ -88,7 +88,7 @@ const SelectContent = ({
 		>
 			<SelectScrollUpButton />
 			<SelectPrimitive.Viewport
-				className={cn(
+				className={mergeClassNames(
 					"p-1",
 					position === "popper" &&
 						"h-[var(--radix-select-trigger-height)] w-full min-w-[var(--radix-select-trigger-width)]",
@@ -108,7 +108,10 @@ const SelectLabel = ({
 }: React.ComponentPropsWithRef<typeof SelectPrimitive.Label>) => (
 	<SelectPrimitive.Label
 		ref={ref}
-		className={cn("py-1.5 pl-8 pr-2 text-sm font-semibold", className)}
+		className={mergeClassNames(
+			"py-1.5 pl-8 pr-2 text-sm font-semibold",
+			className,
+		)}
 		{...props}
 	/>
 );
@@ -121,7 +124,7 @@ const SelectItem = ({
 }: React.ComponentPropsWithRef<typeof SelectPrimitive.Item>) => (
 	<SelectPrimitive.Item
 		ref={ref}
-		className={cn(
+		className={mergeClassNames(
 			"relative flex w-full cursor-default select-none items-center rounded-sm py-1.5 pl-8 pr-2 text-sm outline-none focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
 			className,
 		)}
@@ -144,7 +147,7 @@ const SelectSeparator = ({
 }: React.ComponentPropsWithRef<typeof SelectPrimitive.Separator>) => (
 	<SelectPrimitive.Separator
 		ref={ref}
-		className={cn("-mx-1 my-1 h-px bg-muted", className)}
+		className={mergeClassNames("-mx-1 my-1 h-px bg-muted", className)}
 		{...props}
 	/>
 );

--- a/src/components/ui/switch.tsx
+++ b/src/components/ui/switch.tsx
@@ -3,7 +3,7 @@
 import * as React from "react";
 import * as SwitchPrimitives from "@radix-ui/react-switch";
 
-import { cn } from "@/lib/utils";
+import { mergeClassNames } from "@/lib/utils";
 
 const Switch = ({
 	className,
@@ -11,7 +11,7 @@ const Switch = ({
 	...props
 }: React.ComponentPropsWithRef<typeof SwitchPrimitives.Root>) => (
 	<SwitchPrimitives.Root
-		className={cn(
+		className={mergeClassNames(
 			"peer inline-flex h-6 w-11 shrink-0 cursor-pointer items-center rounded-full border-2 border-transparent transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background disabled:cursor-not-allowed disabled:opacity-50 data-[state=checked]:bg-primary data-[state=unchecked]:bg-input",
 			className,
 		)}
@@ -19,7 +19,7 @@ const Switch = ({
 		ref={ref}
 	>
 		<SwitchPrimitives.Thumb
-			className={cn(
+			className={mergeClassNames(
 				"pointer-events-none block h-5 w-5 rounded-full bg-background shadow-lg ring-0 transition-transform data-[state=checked]:translate-x-5 data-[state=unchecked]:translate-x-0",
 			)}
 		/>

--- a/src/components/ui/text-field.tsx
+++ b/src/components/ui/text-field.tsx
@@ -1,6 +1,6 @@
 import * as React from "react";
 
-import { cn } from "@/lib/utils";
+import { mergeClassNames } from "@/lib/utils";
 
 export type TextFieldProps = Exclude<
 	React.InputHTMLAttributes<HTMLInputElement>,
@@ -12,7 +12,7 @@ const TextField = ({ className, ref, ...props }: TextFieldProps) => {
 	return (
 		<input
 			type="text"
-			className={cn(
+			className={mergeClassNames(
 				"flex items-center justify-center whitespace-nowrap rounded-md text-sm font-medium ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 border border-input bg-background hover:bg-accent hover:text-accent-foreground h-10 px-4 py-2",
 				className,
 			)}

--- a/src/components/ui/toast.tsx
+++ b/src/components/ui/toast.tsx
@@ -5,7 +5,7 @@ import * as ToastPrimitives from "@radix-ui/react-toast";
 import { cva, type VariantProps } from "class-variance-authority";
 import { X } from "lucide-react";
 
-import { cn } from "@/lib/utils";
+import { mergeClassNames } from "@/lib/utils";
 
 const ToastProvider = ToastPrimitives.Provider;
 
@@ -16,7 +16,7 @@ const ToastViewport = ({
 }: React.ComponentPropsWithRef<typeof ToastPrimitives.Viewport>) => (
 	<ToastPrimitives.Viewport
 		ref={ref}
-		className={cn(
+		className={mergeClassNames(
 			"fixed top-0 z-[100] flex max-h-screen w-full flex-col-reverse p-4 sm:bottom-0 sm:right-0 sm:top-auto sm:flex-col md:max-w-[420px]",
 			className,
 		)}
@@ -50,7 +50,7 @@ const Toast = ({
 	return (
 		<ToastPrimitives.Root
 			ref={ref}
-			className={cn(toastVariants({ variant }), className)}
+			className={mergeClassNames(toastVariants({ variant }), className)}
 			{...props}
 		/>
 	);
@@ -63,7 +63,7 @@ const ToastAction = ({
 }: React.ComponentPropsWithRef<typeof ToastPrimitives.Action>) => (
 	<ToastPrimitives.Action
 		ref={ref}
-		className={cn(
+		className={mergeClassNames(
 			"inline-flex h-8 shrink-0 items-center justify-center rounded-md border bg-transparent px-3 text-sm font-medium ring-offset-background transition-colors hover:bg-secondary focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 group-[.destructive]:border-muted/40 group-[.destructive]:hover:border-destructive/30 group-[.destructive]:hover:bg-destructive group-[.destructive]:hover:text-destructive-foreground group-[.destructive]:focus:ring-destructive",
 			className,
 		)}
@@ -78,7 +78,7 @@ const ToastClose = ({
 }: React.ComponentPropsWithRef<typeof ToastPrimitives.Close>) => (
 	<ToastPrimitives.Close
 		ref={ref}
-		className={cn(
+		className={mergeClassNames(
 			"absolute right-2 top-2 rounded-md p-1 text-foreground/50 opacity-0 transition-opacity hover:text-foreground focus:opacity-100 focus:outline-none focus:ring-2 group-hover:opacity-100 group-[.destructive]:text-red-300 group-[.destructive]:hover:text-red-50 group-[.destructive]:focus:ring-red-400 group-[.destructive]:focus:ring-offset-red-600",
 			className,
 		)}
@@ -96,7 +96,7 @@ const ToastTitle = ({
 }: React.ComponentPropsWithRef<typeof ToastPrimitives.Title>) => (
 	<ToastPrimitives.Title
 		ref={ref}
-		className={cn("text-sm font-semibold", className)}
+		className={mergeClassNames("text-sm font-semibold", className)}
 		{...props}
 	/>
 );
@@ -108,7 +108,7 @@ const ToastDescription = ({
 }: React.ComponentPropsWithRef<typeof ToastPrimitives.Description>) => (
 	<ToastPrimitives.Description
 		ref={ref}
-		className={cn("text-sm opacity-90", className)}
+		className={mergeClassNames("text-sm opacity-90", className)}
 		{...props}
 	/>
 );

--- a/src/components/ui/toggle-group.tsx
+++ b/src/components/ui/toggle-group.tsx
@@ -4,7 +4,7 @@ import * as React from "react";
 import * as ToggleGroupPrimitive from "@radix-ui/react-toggle-group";
 import { VariantProps } from "class-variance-authority";
 
-import { cn } from "@/lib/utils";
+import { mergeClassNames } from "@/lib/utils";
 import { toggleVariants } from "@/components/ui/toggle";
 
 const ToggleGroupContext = React.createContext<
@@ -25,7 +25,10 @@ const ToggleGroup = ({
 	VariantProps<typeof toggleVariants>) => (
 	<ToggleGroupPrimitive.Root
 		ref={ref}
-		className={cn("flex items-center justify-center gap-1", className)}
+		className={mergeClassNames(
+			"flex items-center justify-center gap-1",
+			className,
+		)}
 		{...props}
 	>
 		<ToggleGroupContext value={{ variant, size }}>
@@ -48,7 +51,7 @@ const ToggleGroupItem = ({
 	return (
 		<ToggleGroupPrimitive.Item
 			ref={ref}
-			className={cn(
+			className={mergeClassNames(
 				toggleVariants({
 					variant: context.variant || variant,
 					size: context.size || size,

--- a/src/components/ui/toggle.tsx
+++ b/src/components/ui/toggle.tsx
@@ -4,7 +4,7 @@ import * as React from "react";
 import * as TogglePrimitive from "@radix-ui/react-toggle";
 import { cva, type VariantProps } from "class-variance-authority";
 
-import { cn } from "@/lib/utils";
+import { mergeClassNames } from "@/lib/utils";
 
 const toggleVariants = cva(
 	"inline-flex items-center justify-center rounded-md text-sm font-medium ring-offset-background transition-colors hover:bg-muted hover:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 data-[state=on]:bg-accent data-[state=on]:text-accent-foreground",
@@ -38,7 +38,9 @@ const Toggle = ({
 	VariantProps<typeof toggleVariants>) => (
 	<TogglePrimitive.Root
 		ref={ref}
-		className={cn(toggleVariants({ variant, size, className }))}
+		className={mergeClassNames(
+			toggleVariants({ variant, size, className }),
+		)}
 		{...props}
 	/>
 );

--- a/src/components/wrap.tsx
+++ b/src/components/wrap.tsx
@@ -2,7 +2,7 @@
 
 import { WrapTextIcon } from "lucide-react";
 import { useExplorer } from "@/hooks/use-explorer";
-import { cn } from "@/lib/utils";
+import { mergeClassNames } from "@/lib/utils";
 import { Button } from "./ui/button";
 import type { FC } from "react";
 
@@ -23,7 +23,7 @@ export const Wrap: FC = () => {
 		<Button
 			onClick={() => setWrap(!wrap)}
 			variant={wrap ? "outline" : "ghost"}
-			className={cn(
+			className={mergeClassNames(
 				"flex items-center gap-2",
 				!wrap && "text-muted-foreground border border-transparent",
 			)}

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -2,7 +2,8 @@ import { clsx } from "clsx";
 import { twMerge } from "tailwind-merge";
 import type { ClassValue } from "clsx";
 
-export const cn = (...inputs: ClassValue[]): string => twMerge(clsx(inputs));
+export const mergeClassNames = (...inputs: ClassValue[]): string =>
+	twMerge(clsx(inputs));
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export function debounce<T extends (...args: any[]) => void>(


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/.github/blob/master/CONTRIBUTING.md).

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Update or create tests
    - If performance-related, include a benchmark
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What is the purpose of this pull request?

This PR improves the editor’s drag-and-drop experience by eliminating overlay flicker while dragging within the editor and ensuring that dropping a file reliably inserts its content instead of triggering browser navigation.

#### What changes did you make? (Give an overview)

- Stabilized drag state by tracking drag depth, handling only file drags, and resetting on drop/dragend.
- Prevented navigation during drag/drop and simplified overlay visibility to remove flicker.

#### Related Issues

Fixes #128

<!-- include tags like "fixes #123" or "refs #123" -->

#### Is there anything you'd like reviewers to focus on?
