### PR TITLE
refactor: remove unnecessary `"use client"` and `"use server"` directives

### DIFF
--- a/src/components/LabeledSelect.tsx
+++ b/src/components/LabeledSelect.tsx
@@ -1,5 +1,3 @@
-"use client";
-
 import {
 	Select,
 	SelectContent,

--- a/src/components/ast/ast-view-mode.tsx
+++ b/src/components/ast/ast-view-mode.tsx
@@ -1,5 +1,3 @@
-"use client";
-
 import { useExplorer } from "@/hooks/use-explorer";
 import { ToggleGroup, ToggleGroupItem } from "@/components/ui/toggle-group";
 import { astViewOptions } from "@/lib/const";

--- a/src/components/ast/index.tsx
+++ b/src/components/ast/index.tsx
@@ -1,5 +1,3 @@
-"use client";
-
 import { useExplorer } from "@/hooks/use-explorer";
 import { JavascriptAst } from "./javascript-ast";
 import { JsonAst } from "./json-ast";

--- a/src/components/editor.tsx
+++ b/src/components/editor.tsx
@@ -1,5 +1,3 @@
-"use client";
-
 import { useEffect, useRef, useState, FC, useMemo } from "react";
 import { useExplorer, type Language } from "@/hooks/use-explorer";
 import CodeMirror from "@uiw/react-codemirror";

--- a/src/components/mode-toggle.tsx
+++ b/src/components/mode-toggle.tsx
@@ -1,5 +1,3 @@
-"use client";
-
 import { MoonIcon, SunIcon, Monitor } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import {

--- a/src/components/options.tsx
+++ b/src/components/options.tsx
@@ -1,5 +1,3 @@
-"use client";
-
 import {
 	Popover,
 	PopoverContent,

--- a/src/components/path/index.tsx
+++ b/src/components/path/index.tsx
@@ -1,5 +1,3 @@
-"use client";
-
 import { useState, useEffect } from "react";
 import { useExplorer } from "@/hooks/use-explorer";
 import { Editor } from "../editor";

--- a/src/components/path/path-index-selector.tsx
+++ b/src/components/path/path-index-selector.tsx
@@ -1,5 +1,3 @@
-"use client";
-
 import { useExplorer } from "@/hooks/use-explorer";
 import {
 	Select,

--- a/src/components/path/path-view-mode.tsx
+++ b/src/components/path/path-view-mode.tsx
@@ -1,5 +1,3 @@
-"use client";
-
 import { useExplorer } from "@/hooks/use-explorer";
 import { ToggleGroup, ToggleGroupItem } from "@/components/ui/toggle-group";
 import { pathViewOptions } from "@/lib/const";

--- a/src/components/scope/index.tsx
+++ b/src/components/scope/index.tsx
@@ -1,5 +1,3 @@
-"use client";
-
 import * as espree from "espree";
 import * as eslintScope from "eslint-scope";
 import { useExplorer } from "@/hooks/use-explorer";

--- a/src/components/scope/scope-view-mode.tsx
+++ b/src/components/scope/scope-view-mode.tsx
@@ -1,5 +1,3 @@
-"use client";
-
 import { useExplorer } from "@/hooks/use-explorer";
 import { ToggleGroup, ToggleGroupItem } from "@/components/ui/toggle-group";
 import { scopeViewOptions } from "@/lib/const";

--- a/src/components/ui/accordion.tsx
+++ b/src/components/ui/accordion.tsx
@@ -1,5 +1,3 @@
-"use client";
-
 import * as React from "react";
 import * as AccordionPrimitive from "@radix-ui/react-accordion";
 import { ChevronDown } from "lucide-react";

--- a/src/components/ui/dialog.tsx
+++ b/src/components/ui/dialog.tsx
@@ -1,5 +1,3 @@
-"use client";
-
 import * as React from "react";
 import * as DialogPrimitive from "@radix-ui/react-dialog";
 import { X } from "lucide-react";

--- a/src/components/ui/dropdown-menu.tsx
+++ b/src/components/ui/dropdown-menu.tsx
@@ -1,5 +1,3 @@
-"use client";
-
 import * as React from "react";
 import * as DropdownMenuPrimitive from "@radix-ui/react-dropdown-menu";
 import { Check, ChevronRight, Circle } from "lucide-react";

--- a/src/components/ui/label.tsx
+++ b/src/components/ui/label.tsx
@@ -1,5 +1,3 @@
-"use client";
-
 import * as React from "react";
 import * as LabelPrimitive from "@radix-ui/react-label";
 import { cva, type VariantProps } from "class-variance-authority";

--- a/src/components/ui/popover.tsx
+++ b/src/components/ui/popover.tsx
@@ -1,5 +1,3 @@
-"use client";
-
 import * as React from "react";
 import * as PopoverPrimitive from "@radix-ui/react-popover";
 

--- a/src/components/ui/select.tsx
+++ b/src/components/ui/select.tsx
@@ -1,5 +1,3 @@
-"use client";
-
 import * as React from "react";
 import * as SelectPrimitive from "@radix-ui/react-select";
 import { Check, ChevronDown, ChevronUp } from "lucide-react";

--- a/src/components/ui/switch.tsx
+++ b/src/components/ui/switch.tsx
@@ -1,5 +1,3 @@
-"use client";
-
 import * as React from "react";
 import * as SwitchPrimitives from "@radix-ui/react-switch";
 

--- a/src/components/ui/toast.tsx
+++ b/src/components/ui/toast.tsx
@@ -1,5 +1,3 @@
-"use client";
-
 import * as React from "react";
 import * as ToastPrimitives from "@radix-ui/react-toast";
 import { cva, type VariantProps } from "class-variance-authority";

--- a/src/components/ui/toaster.tsx
+++ b/src/components/ui/toaster.tsx
@@ -1,5 +1,3 @@
-"use client";
-
 import {
 	Toast,
 	ToastClose,

--- a/src/components/ui/toggle-group.tsx
+++ b/src/components/ui/toggle-group.tsx
@@ -1,5 +1,3 @@
-"use client";
-
 import * as React from "react";
 import * as ToggleGroupPrimitive from "@radix-ui/react-toggle-group";
 import { VariantProps } from "class-variance-authority";

--- a/src/components/ui/toggle.tsx
+++ b/src/components/ui/toggle.tsx
@@ -1,5 +1,3 @@
-"use client";
-
 import * as React from "react";
 import * as TogglePrimitive from "@radix-ui/react-toggle";
 import { cva, type VariantProps } from "class-variance-authority";

--- a/src/components/ui/use-toast.ts
+++ b/src/components/ui/use-toast.ts
@@ -1,5 +1,3 @@
-"use client";
-
 // Inspired by react-hot-toast library
 import * as React from "react";
 

--- a/src/components/wrap.tsx
+++ b/src/components/wrap.tsx
@@ -1,5 +1,3 @@
-"use client";
-
 import { WrapTextIcon } from "lucide-react";
 import { useExplorer } from "@/hooks/use-explorer";
 import { mergeClassNames } from "@/lib/utils";

--- a/src/lib/generate-code-path.ts
+++ b/src/lib/generate-code-path.ts
@@ -1,7 +1,5 @@
 // @ts-nocheck
 
-"use server";
-
 import { Linter } from "eslint-linter-browserify";
 import { CodePathStack } from "@/lib/code-path-stack";
 import type { SourceType, Version } from "@/hooks/use-explorer";


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/.github/blob/master/CONTRIBUTING.md).

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Update or create tests
    - If performance-related, include a benchmark
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What is the purpose of this pull request?

In this PR, I've removed unnecessary ` "use client" ` and ` "use server" ` directives.

According to the official React documentation and my understanding, the [`"use client"`](https://react.dev/reference/rsc/use-client) and [`"use server"`](https://react.dev/reference/rsc/use-server) directives only have meaning when used in the context of React Server Components.

However, Code Explorer is currently a Single Page Application (SPA), and the React Server Component paradigm is not used anywhere.

Therefore, removing these directives should be safe, and I confirmed this change introduces no side effects.

Additionally, there were a warning caused by the ` "use server" ` directive when running `npm run build`, as shown below:

<img width="1057" height="26" alt="스크린샷 2025-08-30 184836" src="https://github.com/user-attachments/assets/cace9741-a55d-4f11-afc6-ce18deb38a2f" />

Since this change, the warning no longer appears.

#### What changes did you make? (Give an overview)

In this PR, I've removed unnecessary ` "use client" ` and ` "use server" ` directives.

#### Related Issues

N/A

<!-- include tags like "fixes #123" or "refs #123" -->

#### Is there anything you'd like reviewers to focus on?

N/A
