### PR TITLE
chore:  Fix Node.js v22 compatibility by converting Tailwind config to ES modules

### DIFF
--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,5 +1,7 @@
+import tailwindcssAnimate from "tailwindcss-animate";
+
 /** @type {import('tailwindcss').Config} */
-module.exports = {
+export default {
 	darkMode: ["class"],
 	content: ["./{pages,components,app,src}/**/*.{ts,tsx}"],
 	theme: {
@@ -84,7 +86,7 @@ module.exports = {
 		},
 	},
 	plugins: [
-		require("tailwindcss-animate"),
+		tailwindcssAnimate,
 		function ({ addUtilities, theme }) {
 			addUtilities(
 				{


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/.github/blob/master/CONTRIBUTING.md).

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Update or create tests
    - If performance-related, include a benchmark
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What is the purpose of this pull request?
This PR resolves a ReferenceError: module is not defined error that occurs when running the application on Node.js v22. The error was caused by a module system mismatch where the project uses ES modules ("type": "module" in package.json) but the Tailwind config file was using CommonJS syntax, which Node.js v22 enforces more strictly than previous versions.

<img width="1000" height="582" alt="image" src="https://github.com/user-attachments/assets/4320a638-74d6-440b-94f3-accb17ecbfc1" />


#### What changes did you make? (Give an overview)
Converted `tailwind.config.js` from CommonJS to ES module syntax:
1,. Changed export syntax: Replaced module.exports = { with export default {
2. Updated import syntax: Replaced require("tailwindcss-animate") with import tailwindcssAnimate from "tailwindcss-animate"

This change ensures compatibility with Node.js v22+ while maintaining backward compatibility with earlier versions, and aligns the configuration with the project's ES module setup.

#### Related Issues

<!-- include tags like "fixes #123" or "refs #123" -->

#### Is there anything you'd like reviewers to focus on?
