### PR TITLE
refactor: simplify `ASTTreeItem` and `ASTNode` imports

### DIFF
--- a/src/components/ast/index.tsx
+++ b/src/components/ast/index.tsx
@@ -4,8 +4,7 @@ import { useExplorer } from "@/hooks/use-explorer";
 import { Accordion } from "@/components/ui/accordion";
 import { Editor } from "@/components/editor";
 import { ErrorState } from "@/components/error-boundary";
-import { ASTTreeItem } from "@/components/ast/ast-tree-item";
-import type { ASTNode } from "@/components/ast/ast-tree-item";
+import { ASTTreeItem, type ASTNode } from "@/components/ast/ast-tree-item";
 import { parseError } from "@/lib/parse-error";
 
 export const AST: FC = () => {


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/.github/blob/master/CONTRIBUTING.md).

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Update or create tests
    - If performance-related, include a benchmark
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What is the purpose of this pull request?

Simplify and clean up the import statements in the AST component by merging the value and type imports for `ASTTreeItem` and `ASTNode` .

#### What changes did you make? (Give an overview)

Combined the separate import and type import statements for `ASTTreeItem` and `ASTNode` into a single import line

#### Related Issues

https://github.com/eslint/code-explorer/pull/162/files/2bf4c1bb5d8c16b4a432469044af214ca3701303#r2404579633

<!-- include tags like "fixes #123" or "refs #123" -->

#### Is there anything you'd like reviewers to focus on?
