### PR TITLE
fix: improve accessible labels for CodeMirror views

### DIFF
--- a/src/app.tsx
+++ b/src/app.tsx
@@ -35,6 +35,7 @@ function App() {
 								>
 									<EsquerySelectorInput />
 									<Editor
+										ariaLabel="Code Editor"
 										value={code[language]}
 										highlightedRanges={
 											astParseResult.ok

--- a/src/components/ast/index.tsx
+++ b/src/components/ast/index.tsx
@@ -40,5 +40,11 @@ export const AST: FC = () => {
 		);
 	}
 
-	return <Editor readOnly value={JSON.stringify(result.ast, null, 2)} />;
+	return (
+		<Editor
+			ariaLabel="AST JSON"
+			readOnly
+			value={JSON.stringify(result.ast, null, 2)}
+		/>
+	);
 };

--- a/src/components/editor.tsx
+++ b/src/components/editor.tsx
@@ -28,6 +28,7 @@ const languageExtensions: Record<
 };
 
 type EditorProperties = {
+	ariaLabel: string;
 	readOnly?: boolean;
 	value?: string;
 	highlightedRanges?: SourceRange[];
@@ -35,6 +36,7 @@ type EditorProperties = {
 };
 
 export const Editor: FC<EditorProperties> = ({
+	ariaLabel,
 	readOnly,
 	value,
 	highlightedRanges = [],
@@ -55,11 +57,12 @@ export const Editor: FC<EditorProperties> = ({
 		() => [
 			activeLanguageExtension,
 			wrap ? EditorView.lineWrapping : [],
+			EditorView.contentAttributes.of({ "aria-label": ariaLabel }),
 			ESLintPlaygroundTheme,
 			ESLintPlaygroundHighlightStyle,
 			highlightedRangesExtension(highlightedRanges),
 		],
-		[activeLanguageExtension, wrap, highlightedRanges],
+		[activeLanguageExtension, wrap, ariaLabel, highlightedRanges],
 	);
 
 	const debouncedOnChange = useMemo(
@@ -173,7 +176,6 @@ export const Editor: FC<EditorProperties> = ({
 				</div>
 			)}
 			<CodeMirror
-				aria-label="Code Editor"
 				className="h-full overflow-auto scrollbar-thumb scrollbar-track text-sm"
 				value={value}
 				extensions={editorExtensions}

--- a/src/components/path/index.tsx
+++ b/src/components/path/index.tsx
@@ -91,7 +91,7 @@ export const CodePath: FC = () => {
 	const codePath = extracted.codePathList[index].dot;
 
 	if (pathView === "code") {
-		return <Editor readOnly value={codePath} />;
+		return <Editor ariaLabel="Code Path" readOnly value={codePath} />;
 	}
 
 	return (


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/.github/blob/master/CONTRIBUTING.md).

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Update or create tests
    - If performance-related, include a benchmark
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### AI acknowledgment

- [x] I did _not_ use AI to generate this PR.
- [ ] (If the above is not checked) I have reviewed the AI-generated content before submitting.

#### What is the purpose of this pull request?

This PR fixes how accessible labels are applied to our CodeMirror views. It moves the label to the actual editable element and gives each editor surface a clearer accessible name.

#### What changes did you make? (Give an overview)

- Moved the editor accessible name onto CodeMirror's editable content using `EditorView.contentAttributes`.
- Removed the wrapper-level `aria-label` usage from the `CodeMirror` component call site.
- Added explicit labels for each editor instance so the main source editor, AST JSON view, and code path view are announced distinctly.


#### Related Issues

<!-- include tags like "fixes #123" or "refs #123" -->

#### Is there anything you'd like reviewers to focus on?
