### PR TITLE
fix: update react-resizable-panels to v4.10.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -43,6 +43,7 @@
         "lucide-react": "^0.577.0",
         "react": "^19.2.4",
         "react-dom": "^19.2.4",
+        "react-resizable-panels": "^4.10.0",
         "tailwind-merge": "^2.6.1",
         "tailwindcss-animate": "^1.0.7",
         "zustand": "^4.5.7"
@@ -68,7 +69,6 @@
         "lint-staged": "^15.5.2",
         "postcss": "^8.5.8",
         "prettier": "3.8.1",
-        "react-resizable-panels": "^3.0.6",
         "tailwindcss": "^3.4.19",
         "typescript": "^6.0.2",
         "typescript-eslint": "^8.58.0",
@@ -8795,14 +8795,13 @@
       }
     },
     "node_modules/react-resizable-panels": {
-      "version": "3.0.6",
-      "resolved": "https://registry.npmjs.org/react-resizable-panels/-/react-resizable-panels-3.0.6.tgz",
-      "integrity": "sha512-b3qKHQ3MLqOgSS+FRYKapNkJZf5EQzuf6+RLiq1/IlTHw99YrZ2NJZLk4hQIzTnnIkRg2LUqyVinu6YWWpUYew==",
-      "dev": true,
+      "version": "4.10.0",
+      "resolved": "https://registry.npmjs.org/react-resizable-panels/-/react-resizable-panels-4.10.0.tgz",
+      "integrity": "sha512-frjewRQt7TCv/vCH1pJfjZ7RxAhr5pKuqVQtVgzFq/vherxBFOWyC3xMbryx5Ti2wylViGUFc93Etg4rB3E0UA==",
       "license": "MIT",
       "peerDependencies": {
-        "react": "^16.14.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc",
-        "react-dom": "^16.14.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/react-style-singleton": {

--- a/package.json
+++ b/package.json
@@ -67,6 +67,7 @@
     "lucide-react": "^0.577.0",
     "react": "^19.2.4",
     "react-dom": "^19.2.4",
+    "react-resizable-panels": "^4.10.0",
     "tailwind-merge": "^2.6.1",
     "tailwindcss-animate": "^1.0.7",
     "zustand": "^4.5.7"
@@ -92,7 +93,6 @@
     "lint-staged": "^15.5.2",
     "postcss": "^8.5.8",
     "prettier": "3.8.1",
-    "react-resizable-panels": "^3.0.6",
     "tailwindcss": "^3.4.19",
     "typescript": "^6.0.2",
     "typescript-eslint": "^8.58.0",

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -1,4 +1,4 @@
-import { Panel, PanelGroup, PanelResizeHandle } from "react-resizable-panels";
+import { Group, Panel, Separator } from "react-resizable-panels";
 import { Editor } from "@/components/editor";
 import { EsquerySelectorInput } from "@/components/esquery-selector-input";
 import { Navbar } from "@/components/navbar";
@@ -23,13 +23,10 @@ function App() {
 					<Navbar />
 					<div className="h-full overflow-hidden">
 						<div className="border-t h-full">
-							<PanelGroup
-								direction="horizontal"
-								className="border-t h-full"
-							>
+							<Group className="border-t h-full">
 								<Panel
-									defaultSize={50}
-									minSize={25}
+									defaultSize="50%"
+									minSize="25%"
 									role="region"
 									aria-label="Code Editor Panel"
 								>
@@ -51,10 +48,10 @@ function App() {
 										}}
 									/>
 								</Panel>
-								<PanelResizeHandle className="w-2 bg-gutter dark:bg-gray-600 bg-gray-200 bg-no-repeat bg-center" />
+								<Separator className="w-2 bg-gutter dark:bg-gray-600 bg-gray-200 bg-no-repeat bg-center" />
 								<Panel
-									defaultSize={50}
-									minSize={25}
+									defaultSize="50%"
+									minSize="25%"
 									role="region"
 									aria-label="Code Analysis Tools Panel"
 								>
@@ -72,7 +69,7 @@ function App() {
 										<activeTool.component />
 									</div>
 								</Panel>
-							</PanelGroup>
+							</Group>
 						</div>
 					</div>
 				</div>


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/.github/blob/master/CONTRIBUTING.md).

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Update or create tests
    - If performance-related, include a benchmark
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### AI acknowledgment

- [x] I did _not_ use AI to generate this PR.
- [ ] (If the above is not checked) I have reviewed the AI-generated content before submitting.

#### What is the purpose of this pull request?

This PR updates `react-resizable-panels` to the latest v4 release and updates the app to the current API so the editor split view continues to behave the same way after the dependency bump.

#### What changes did you make? (Give an overview)

- Updated `react-resizable-panels` to `^4.10.0`.
- Moved `react-resizable-panels` from `devDependencies` to `dependencies` since it is imported by runtime app code.
- Migrated the app from `PanelGroup` and `PanelResizeHandle` to the v4 `Group` and `Separator` components.
- Converted panel size props from numeric values to percentage strings to preserve the existing 50/50 layout and 25% minimum panel widths under v4.

#### Related Issues

<!-- include tags like "fixes #123" or "refs #123" -->

#### Is there anything you'd like reviewers to focus on?
