### PR TITLE
fix: wrap right panel header controls at narrow width

### DIFF
--- a/src/app.tsx
+++ b/src/app.tsx
@@ -59,9 +59,9 @@ function App() {
 									aria-label="Code Analysis Tools Panel"
 								>
 									<div className="bg-muted overflow-auto h-full relative flex flex-col">
-										<div className="flex sm:items-center flex-col sm:flex-row justify-between p-4 gap-2 z-10">
+										<div className="flex flex-col gap-2 p-4 z-10 sm:flex-row sm:flex-wrap sm:justify-between">
 											<ToolSelector />
-											<div className="flex items-center gap-1">
+											<div className="flex flex-wrap items-center gap-1">
 												{activeTool.options.map(
 													(Option, index) => (
 														<Option key={index} />


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/.github/blob/master/CONTRIBUTING.md).

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Update or create tests
    - If performance-related, include a benchmark
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### AI acknowledgment

- [x] I did _not_ use AI to generate this PR.
- [ ] (If the above is not checked) I have reviewed the AI-generated content before submitting.

#### What is the purpose of this pull request?

This PR improves the layout of the right-side panel when it is resized to a narrow width. Instead of forcing the tool controls and view options to compete for the same row, the header can now wrap, which prevents the AST/Scope/Code Path option buttons from looking compressed.

#### What changes did you make? (Give an overview)

- Updated the right panel header layout to allow the header row to wrap when horizontal space gets tight.
- Allowed the options container to wrap its controls instead of keeping them on a single line.

#### Related Issues

<!-- include tags like "fixes #123" or "refs #123" -->

#### Is there anything you'd like reviewers to focus on?
