### PR TITLE
feat: add option for markdown math

### DIFF
--- a/src/components/options.tsx
+++ b/src/components/options.tsx
@@ -67,7 +67,7 @@ const JSONPanel: FC = () => {
 const MarkdownPanel: FC = () => {
 	const explorer = useExplorer();
 	const { markdownOptions, setMarkdownOptions } = explorer;
-	const { markdownMode, markdownFrontmatter } = markdownOptions;
+	const { markdownMode, markdownFrontmatter, markdownMath } = markdownOptions;
 	return (
 		<>
 			<LabeledSelect
@@ -95,6 +95,18 @@ const MarkdownPanel: FC = () => {
 				}}
 				items={markdownFrontmatters}
 				placeholder="Front Matter"
+			/>
+
+			<LabeledSwitch
+				id="markdownMath"
+				label="Math"
+				checked={markdownMath}
+				onCheckedChange={(value: boolean) => {
+					setMarkdownOptions({
+						...markdownOptions,
+						markdownMath: value,
+					});
+				}}
 			/>
 		</>
 	);

--- a/src/hooks/use-ast.ts
+++ b/src/hooks/use-ast.ts
@@ -66,7 +66,8 @@ export function useAST() {
 		}
 
 		case "markdown": {
-			const { markdownMode, markdownFrontmatter } = markdownOptions;
+			const { markdownMode, markdownFrontmatter, markdownMath } =
+				markdownOptions;
 			const language = markdown.languages[markdownMode];
 			astParseResult = language.parse(
 				{ body: code.markdown, path: "", physicalPath: "", bom: false },
@@ -76,6 +77,7 @@ export function useAST() {
 							markdownFrontmatter === "off"
 								? false
 								: markdownFrontmatter,
+						math: markdownMath,
 					},
 				},
 			);

--- a/src/hooks/use-explorer.ts
+++ b/src/hooks/use-explorer.ts
@@ -48,6 +48,7 @@ export type JsonOptions = {
 export type MarkdownOptions = {
 	markdownMode: MarkdownMode;
 	markdownFrontmatter: MarkdownFrontmatter;
+	markdownMath: boolean;
 };
 
 export type CssOptions = {

--- a/src/lib/const.ts
+++ b/src/lib/const.ts
@@ -484,6 +484,7 @@ export const defaultJsonOptions: JsonOptions = {
 export const defaultMarkdownOptions: MarkdownOptions = {
 	markdownMode: "commonmark",
 	markdownFrontmatter: "off",
+	markdownMath: false,
 };
 
 export const defaultCssOptions: CssOptions = {


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/.github/blob/master/CONTRIBUTING.md).

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Update or create tests
    - If performance-related, include a benchmark
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### AI acknowledgment

- [x] I did _not_ use AI to generate this PR.
- [ ] (If the above is not checked) I have reviewed the AI-generated content before submitting.

#### What is the purpose of this pull request?
Add the option `math` for markdown.

#### What changes did you make? (Give an overview)
- Add a checkbox to the markdown options
- Update the markdown option defaults and type
- Pass the option to the language

#### Related Issues
None, this just allows passing all possible options available for the markdown language.
<!-- include tags like "fixes #123" or "refs #123" -->

#### Is there anything you'd like reviewers to focus on?
- I am open about a different name than `markdownMath` (maybe `enableMath`?)
- Should this be enabled by default? I chose disabled as this is the default for the markdown language but this can be seen as similar to the default enabled JSX.
