### PR TITLE
feat: add line number to error message

### DIFF
--- a/src/lib/parse-error.ts
+++ b/src/lib/parse-error.ts
@@ -9,10 +9,12 @@ export const parseError = (error: unknown): string => {
 
 		if ("lineNumber" in error && "column" in error) {
 			message += ` (${error.lineNumber}:${error.column})`;
+		} else if ("line" in error && "column" in error) {
+			message += ` (${error.line}:${error.column})`;
 		} else if ("lineNumber" in error) {
-			message += `(line ${error.lineNumber})`;
+			message += ` (line ${error.lineNumber})`;
 		} else if ("column" in error) {
-			message += `(column ${error.column})`;
+			message += ` (column ${error.column})`;
 		}
 	} else {
 		message = String(error);


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/.github/blob/master/CONTRIBUTING.md).

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Update or create tests
    - If performance-related, include a benchmark
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### AI acknowledgment

- [x] I did _not_ use AI to generate this PR.
- [ ] (If the above is not checked) I have reviewed the AI-generated content before submitting.

#### What is the purpose of this pull request?
To add the line number also in the error message.

#### What changes did you make? (Give an overview)
Right now, the parsing error in the `css` code only has a column number in it, not line number.
<img width="298" height="78" alt="Screenshot 2026-05-09 150933" src="https://github.com/user-attachments/assets/ab22bab6-554b-4a9a-a2e5-d0d41fa916cc" />

Added a condition to check if `error` has both `line` and `column` properties in it, then added both line and column to the error message. Also added space before the `line` and `column` when they are alone.
<img width="243" height="131" alt="Screenshot 2026-05-09 150627" src="https://github.com/user-attachments/assets/e7891442-2241-4b30-b233-f675a6accdea" />


#### Related Issues

<!-- include tags like "fixes #123" or "refs #123" -->

#### Is there anything you'd like reviewers to focus on?
