### PR TITLE
fix: remove leading newline from generated code path

### DIFF
--- a/src/lib/generate-code-path.ts
+++ b/src/lib/generate-code-path.ts
@@ -156,7 +156,6 @@ export const generateCodePath = async (
 			const { codePath } = target;
 
 			let text =
-				"\n" +
 				"digraph {\n" +
 				'    bgcolor="transparent";\n' +
 				'    node[shape=box,style="rounded,filled",fillcolor=white,color="#E4E7EC"];\n' +


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/.github/blob/master/CONTRIBUTING.md).

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Update or create tests
    - If performance-related, include a benchmark
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### AI acknowledgment

- [x] I did _not_ use AI to generate this PR.
- [ ] (If the above is not checked) I have reviewed the AI-generated content before submitting.

#### What is the purpose of this pull request?

This PR improves the formatting of the Code Path output. Previously, the generated string included a leading newline, which caused a blank line to appear at the top of the editor when viewing the code path.

#### What changes did you make? (Give an overview)

Removed the unnecessary `\n` prefix from the generated DOT string.

#### Related Issues

<!-- include tags like "fixes #123" or "refs #123" -->

#### Is there anything you'd like reviewers to focus on?
