### PR TITLE
fix: escape code path DOT labels

### DIFF
--- a/src/lib/generate-code-path.ts
+++ b/src/lib/generate-code-path.ts
@@ -53,6 +53,9 @@ const makeDotArrows = codePath => {
 	return `${text} [color="#98A2B3"];`;
 };
 
+const escapeDotLabelText = value =>
+	value.replace(/\\/gu, String.raw`\\`).replace(/"/gu, String.raw`\"`);
+
 export const generateCodePath = async (
 	code: string,
 	esVersion: Version,
@@ -181,7 +184,7 @@ export const generateCodePath = async (
 
 				text +=
 					nodes && nodes.length > 0
-						? nodes.join(String.raw`\n`)
+						? nodes.map(escapeDotLabelText).join(String.raw`\n`)
 						: "????";
 
 				text += '"];\n';


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/.github/blob/master/CONTRIBUTING.md).

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Update or create tests
    - If performance-related, include a benchmark
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### AI acknowledgment

- [x] I did _not_ use AI to generate this PR.
- [ ] (If the above is not checked) I have reviewed the AI-generated content before submitting.

#### What did you do?

I wrote code in the explorer that includes a string literal with a double quote, for example:

```js
const value = '"';
```

Then, I navigated to the Code Path tab.

#### What did you expect to happen?

The Code Path graph should render correctly.

#### What actually happened?

Code Path reports an error: `Error: syntax error in line 6 near ')'`.

#### What is the purpose of this pull request?

Node labels in the generated DOT output are not escaped, so source code containing double quotes or backslashes produces syntactically invalid DOT graphs. This causes the code path visualization to fail to render.

#### What changes did you make? (Give an overview)

- Added an `escapeDotLabelText` helper that escapes `\` and `"` characters in node label text before inserting them into DOT `label="..."` attributes.

#### Related Issues

<!-- include tags like "fixes #123" or "refs #123" -->

#### Is there anything you'd like reviewers to focus on?
