### PR TITLE
ci: add production build verification step

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,6 +46,9 @@ jobs:
             - name: Check formatting of everything (prettier)
               run: npm run fmt:check
 
+            - name: Build production bundle (vite build)
+              run: npm run build
+
     e2e-test:
         name: E2E Tests (Playwright)
         timeout-minutes: 10


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/.github/blob/master/CONTRIBUTING.md).

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Update or create tests
    - If performance-related, include a benchmark
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### AI acknowledgment

- [x] I did _not_ use AI to generate this PR.
- [ ] (If the above is not checked) I have reviewed the AI-generated content before submitting.

#### What is the purpose of this pull request?
Verify that the production bundle actually builds on every PR. Today CI only runs tsc, eslint, and prettier --check — none of which exercise vite build. Any failure that only surfaces at build time would slip through CI and only get caught at deploy time. Adding npm run build to the check job closes that gap and gives PR authors earlier, in-repo feedback instead of a broken deploy.

#### What changes did you make? (Give an overview)
Added a new step (build) to the check job in after the prettier step.

Note — this matches existing ESLint-org convention for app repos (eslint playgorund and config inspector)

#### Related Issues

<!-- include tags like "fixes #123" or "refs #123" -->

#### Is there anything you'd like reviewers to focus on?
