### PR TITLE
ci: bump e2e-test timeout-minutes from 10 to 15

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,7 +48,7 @@ jobs:
 
     e2e-test:
         name: E2E Tests (Playwright)
-        timeout-minutes: 10
+        timeout-minutes: 15
         # run only if triggered by push on a branch or by a PR event for a PR which is not a draft
         if: ${{ !github.event.pull_request || github.event.pull_request.draft == false }}
         runs-on: ubuntu-24.04


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/.github/blob/master/CONTRIBUTING.md).

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Update or create tests
    - If performance-related, include a benchmark
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### AI acknowledgment

- [x] I did _not_ use AI to generate this PR.
- [ ] (If the above is not checked) I have reviewed the AI-generated content before submitting.

#### What is the purpose of this pull request?

In pr https://github.com/eslint/code-explorer/actions/runs/25793764492/job/75765670016?pr=417 Total wall-clock hit 10m 9s. The job has exceeded the maximum execution time of 10m0s. There is effectively zero buffer, so any small variance pushes the job past 10m and GitHub cancels it.

same issue with [this](https://github.com/eslint/code-explorer/pull/417) pr as well
 
#### What changes did you make? (Give an overview)

Bumped bump e2e-test timeout-minutes from 10 to 15. Gives roughly a 5-minute buffer.


#### Related Issues

<!-- include tags like "fixes #123" or "refs #123" -->

#### Is there anything you'd like reviewers to focus on?
