### PR TITLE
fix: align fold gutter markers

### DIFF
--- a/src/components/editor.tsx
+++ b/src/components/editor.tsx
@@ -3,9 +3,9 @@ import { javascript } from "@codemirror/lang-javascript";
 import { markdown } from "@codemirror/lang-markdown";
 import { css } from "@codemirror/lang-css";
 import { html } from "@codemirror/lang-html";
+import { foldGutter, type LanguageSupport } from "@codemirror/language";
 import { EditorView } from "@codemirror/view";
-import { LanguageSupport } from "@codemirror/language";
-import CodeMirror from "@uiw/react-codemirror";
+import CodeMirror, { type BasicSetupOptions } from "@uiw/react-codemirror";
 import { useEffect, useRef, useState, useMemo, type FC } from "react";
 import { useExplorer, type Language } from "@/hooks/use-explorer";
 import { mergeClassNames, debounce } from "@/lib/utils";
@@ -25,6 +25,15 @@ const languageExtensions: Record<
 	markdown: () => markdown(),
 	css: () => css(),
 	html: () => html(),
+};
+
+const foldGutterExtension = foldGutter({
+	closedText: "▸",
+	openText: "▾",
+});
+
+const basicSetup: BasicSetupOptions = {
+	foldGutter: false,
 };
 
 type EditorProperties = {
@@ -56,6 +65,7 @@ export const Editor: FC<EditorProperties> = ({
 	const editorExtensions = useMemo(
 		() => [
 			activeLanguageExtension,
+			foldGutterExtension,
 			wrap ? EditorView.lineWrapping : [],
 			EditorView.contentAttributes.of({ "aria-label": ariaLabel }),
 			ESLintPlaygroundTheme,
@@ -181,6 +191,7 @@ export const Editor: FC<EditorProperties> = ({
 				extensions={editorExtensions}
 				onChange={debouncedOnChange}
 				readOnly={readOnly}
+				basicSetup={basicSetup}
 			/>
 		</div>
 	);


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/.github/blob/master/CONTRIBUTING.md).

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Update or create tests
    - If performance-related, include a benchmark
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### AI acknowledgment

- [x] I did _not_ use AI to generate this PR.
- [ ] (If the above is not checked) I have reviewed the AI-generated content before submitting.

#### What is the purpose of this pull request?

This PR fixes the fold/unfold marker alignment in the CodeMirror gutter. The default unfolded marker was visually off-center next to the line number, so this updates the marker glyphs to use better-aligned triangle characters.

#### What changes did you make? (Give an overview)

- Added a custom CodeMirror `foldGutter` extension using `▸` for folded lines and `▾` for unfolded lines.
- Disabled the default fold gutter from `basicSetup` to avoid rendering duplicate fold controls.

#### Related Issues

<!-- include tags like "fixes #123" or "refs #123" -->

#### Is there anything you'd like reviewers to focus on?
