### PR TITLE
test: simplify playwright storage access in persistence tests

### DIFF
--- a/e2e-tests/persistence.test.ts
+++ b/e2e-tests/persistence.test.ts
@@ -15,35 +15,31 @@ import { expect, test, type Page } from "@playwright/test";
 const storageKey = "eslint-explorer";
 
 async function getPersistedJavaScriptCode(page: Page): Promise<string> {
-	return page.evaluate(key => {
-		const storedValue = window.localStorage.getItem(key);
+	const storedValue = await page.localStorage.getItem(storageKey);
 
-		if (!storedValue) {
-			return "";
-		}
+	if (!storedValue) {
+		return "";
+	}
 
-		return JSON.parse(storedValue).state.code.javascript;
-	}, storageKey);
+	return JSON.parse(storedValue).state.code.javascript;
 }
 
 async function getPersistedExplorerState(page: Page): Promise<string> {
-	return page.evaluate(key => {
-		const storedValue = window.localStorage.getItem(key);
+	const storedValue = await page.localStorage.getItem(storageKey);
 
-		if (!storedValue) {
-			throw new Error("No persisted state found in localStorage");
-		}
+	if (!storedValue) {
+		throw new Error("No persisted state found in localStorage");
+	}
 
-		return storedValue;
-	}, storageKey);
+	return storedValue;
 }
 
-async function getStoredHashValue(page: Page): Promise<string> {
-	return page.evaluate(key => {
-		return (
-			new URLSearchParams(window.location.hash.slice(1)).get(key) ?? ""
-		);
-	}, storageKey);
+function getStoredHashValue(page: Page): string {
+	return (
+		new URLSearchParams(new URL(page.url()).hash.slice(1)).get(
+			storageKey,
+		) ?? ""
+	);
 }
 
 //-----------------------------------------------------------------------------
@@ -67,11 +63,9 @@ test("should persist unicode code safely in the URL hash", async ({ page }) => {
 	await expect.poll(() => getPersistedJavaScriptCode(page)).toBe(unicodeCode);
 	await expect.poll(() => getStoredHashValue(page)).toContain("v2.");
 
-	const persistedHash = await page.evaluate(() => window.location.hash);
+	const persistedHash = new URL(page.url()).hash;
 
-	await page.evaluate(key => {
-		window.localStorage.removeItem(key);
-	}, storageKey);
+	await page.localStorage.removeItem(storageKey);
 	await page.goto(`/${persistedHash}`);
 
 	await expect(codeEditor).toContainText(unicodeCode);
@@ -104,9 +98,7 @@ test("should still load state from legacy hash links", async ({ page }) => {
 		[storageKey, persistedValue],
 	);
 
-	await page.evaluate(key => {
-		window.localStorage.removeItem(key);
-	}, storageKey);
+	await page.localStorage.removeItem(storageKey);
 	await page.goto(`/#${legacyHash}`);
 
 	await expect(codeEditor).toContainText(legacyCode);
@@ -152,12 +144,7 @@ test("should fall back to localStorage when a v2 hash is malformed", async ({
 		return searchParams.toString();
 	}, storageKey);
 
-	await page.evaluate(
-		([key, value]) => {
-			window.localStorage.setItem(key, value);
-		},
-		[storageKey, persistedValue],
-	);
+	await page.localStorage.setItem(storageKey, persistedValue);
 	await page.goto(`/#${malformedHash}`);
 
 	await expect(codeEditor).toContainText(fallbackCode);


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/.github/blob/master/CONTRIBUTING.md).

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Update or create tests
    - If performance-related, include a benchmark
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### AI acknowledgment

- [x] I did _not_ use AI to generate this PR.
- [ ] (If the above is not checked) I have reviewed the AI-generated content before submitting.

#### What is the purpose of this pull request?

Playwright v1.61.0 adds a new [WebStorage](https://playwright.dev/docs/api/class-webstorage) API via `page.localStorage` and `page.sessionStorage` for reading and writing storage on the current origin.

This PR uses that API to simplify our persistence e2e tests and avoid unnecessary `page.evaluate()` calls for `localStorage` access.

#### What changes did you make? (Give an overview)

Replaced `localStorage` reads, writes, and removals with `page.localStorage.getItem()`, `setItem()`, and `removeItem()`. Also simplified hash inspection by reading from `page.url()`.

#### Related Issues

<!-- include tags like "fixes #123" or "refs #123" -->

#### Is there anything you'd like reviewers to focus on?
