### PR TITLE
chore: add allowScripts field to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "test:e2e": "playwright test"
   },
   "allowScripts": {
-    "yorkie": true
+    "yorkie@2.0.0": true
   },
   "lint-staged": {
     "**/*.{js,jsx,ts,tsx}": [

--- a/package.json
+++ b/package.json
@@ -17,6 +17,9 @@
     "fmt:check": "prettier --check .",
     "test:e2e": "playwright test"
   },
+  "allowScripts": {
+    "yorkie": true
+  },
   "lint-staged": {
     "**/*.{js,jsx,ts,tsx}": [
       "eslint --fix",


### PR DESCRIPTION
<!--
    Thank you for contributing!
    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->
#### Prerequisites checklist
- [x] I have read the [contributing guidelines](https://github.com/eslint/.github/blob/master/CONTRIBUTING.md).

#### AI acknowledgment
- [x] I did _not_ use AI to generate this PR.
- [ ] (If the above is not checked) I have reviewed the AI-generated content before submitting.

#### What is the purpose of this pull request?

Add the `allowScripts` field to `package.json` for the npm install scripts policy, following the same approach as the [PR for eslint/eslint](https://github.com/eslint/eslint/pull/21092).

#### What changes did you make? (Give an overview)

Starting with npm 12, install scripts that aren't covered by `allowScripts` are blocked by default. On a fresh install, three packages are blocked: `yorkie` and `fsevents` (×2, macOS-only).

This PR allows only `yorkie`, since it's the only one whose install script is actually required — it installs the git hooks, so when it's blocked the `pre-commit` hook is never created and `lint-staged` no longer runs on commit.

`fsevents` is intentionally left out: its install script isn't required, and the module still loads and works correctly without it.

I left the entry unpinned (`"yorkie": true`) since this repository commits `package-lock.json`, so the version is already locked. I'd be happy to pin it if reviewers prefer.

#### Related Issues

<!-- include tags like "fixes #123" or "refs #123" -->

#### Is there anything you'd like reviewers to focus on?

Verified on npm 12.0.1 / Node.js v24.18.0 (`rm -rf node_modules && npm install`):

- Without `allowScripts`, `yorkie` is blocked and `.git/hooks/pre-commit` is missing.
- With `"yorkie": true`, `yorkie` runs and the hook is created.
- `fsevents` loads correctly even while its install script stays blocked.

I'd appreciate any feedback on whether `fsevents` should be handled explicitly, and on the unpinned-vs-pinned decision.