### PR TITLE
ci: add explicit permissions to add-to-triage.yml

### DIFF
--- a/.github/workflows/add-to-triage.yml
+++ b/.github/workflows/add-to-triage.yml
@@ -12,6 +12,9 @@ on:
             - opened
             - reopened
 
+permissions:
+    contents: read
+
 jobs:
     add-to-triage:
         uses: eslint/workflows/.github/workflows/add-to-triage.yml@main


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/.github/blob/master/CONTRIBUTING.md).

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Update or create tests
    - If performance-related, include a benchmark
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### AI acknowledgment

- [x] I did _not_ use AI to generate this PR.
- [ ] (If the above is not checked) I have reviewed the AI-generated content before submitting.

#### What is the purpose of this pull request?
The `add-to-triage.yml` workflow has no workflow-level permissions declaration, so `GITHUB_TOKEN` is granted the default permissions. This PR restricts them explicitly, following the principle of least privilege.


#### What changes did you make? (Give an overview)
I've added explicit permissions to `add-to-triage.yml` as shown below:

```yml
permissions:
    contents: read
```

#### Related Issues

<!-- include tags like "fixes #123" or "refs #123" -->

#### Is there anything you'd like reviewers to focus on?
