### PR TITLE
chore: use tsconfig paths for Vite resolution

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,4 +1,3 @@
-import path from "node:path";
 import babel from "@rolldown/plugin-babel";
 import { defineConfig } from "vite";
 import react, { reactCompilerPreset } from "@vitejs/plugin-react";
@@ -73,9 +72,7 @@ export default defineConfig({
 		}),
 	],
 	resolve: {
-		alias: {
-			"@": path.resolve(__dirname, "src"),
-		},
+		tsconfigPaths: true,
 	},
 	build: {
 		outDir: "build",


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/.github/blob/master/CONTRIBUTING.md).

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Update or create tests
    - If performance-related, include a benchmark
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### AI acknowledgment

- [x] I did _not_ use AI to generate this PR.
- [ ] (If the above is not checked) I have reviewed the AI-generated content before submitting.

#### What is the purpose of this pull request?

Running `npm start` displayed the following Vite warning:
```
(!) Your Vite config uses features that are unsupported by `configLoader: 'native'`, which is planned to become the default in a future major version of Vite:
  - `__dirname` (vite.config.ts:77:22). Use `import.meta.dirname` instead     
Set `VITE_CONFIG_NATIVE_IGNORE_WARNING=true` to suppress this warning. 
```

#### What changes did you make? (Give an overview)

Enabled Vite’s `resolve.tsconfigPaths` option and removed the manually configured `@` alias.

`resolve.tsconfigPaths` is no longer experimental as of Vite 8.2.0, so it can be used instead of resolving the alias with `__dirname`.

#### Related Issues

<!-- include tags like "fixes #123" or "refs #123" -->

#### Is there anything you'd like reviewers to focus on?
