### PR TITLE
refactor: remove `async` from code path generation

### DIFF
--- a/src/components/path/index.tsx
+++ b/src/components/path/index.tsx
@@ -25,9 +25,9 @@ export const CodePath: FC = () => {
 	const hasMountedDebouncedEffect = useRef(false);
 
 	useEffect(() => {
-		const fetchCodePath = async () => {
+		const fetchCodePath = () => {
 			try {
-				const response = await generateCodePath(
+				const response = generateCodePath(
 					javascript,
 					esVersion,
 					sourceType,

--- a/src/lib/generate-code-path.ts
+++ b/src/lib/generate-code-path.ts
@@ -56,19 +56,18 @@ const makeDotArrows = codePath => {
 const escapeDotLabelText = value =>
 	value.replace(/\\/gu, String.raw`\\`).replace(/"/gu, String.raw`\"`);
 
-export const generateCodePath = async (
+export const generateCodePath = (
 	code: string,
 	esVersion: Version,
 	sourceType: SourceType,
 	isJSX: boolean,
-): Promise<
+):
 	| {
 			error: string;
 	  }
 	| {
 			response: string;
-	  }
-> => {
+	  } => {
 	const linter = new Linter({ configType: "flat" });
 
 	let stack: CodePathStack | null = null;


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/.github/blob/master/CONTRIBUTING.md).

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Update or create tests
    - If performance-related, include a benchmark
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### AI acknowledgment

- [x] I did _not_ use AI to generate this PR.
- [ ] (If the above is not checked) I have reviewed the AI-generated content before submitting.

#### What is the purpose of this pull request?

Remove asynchronous flow from code path generation.

#### What changes did you make? (Give an overview)

Removed `async`, `await`, and `Promise` return type because `generateCodePath` runs synchronously.

#### Related Issues

refs #518

#### Is there anything you'd like reviewers to focus on?

x

Disclosure: I'm a participant of [open source contribution program OSSCA](https://github.com/eslint-ossca)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Streamlined code path generation and response handling.
  * Maintained existing success and error behavior while improving processing efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->