### PR TITLE
refactor: return structured code path data without JSON serialization

### DIFF
--- a/src/components/path/index.tsx
+++ b/src/components/path/index.tsx
@@ -3,15 +3,9 @@ import { useExplorer } from "@/hooks/use-explorer";
 import { Editor } from "../editor";
 import type { FC } from "react";
 import Graphviz from "graphviz-react";
-import { generateCodePath } from "@/lib/generate-code-path";
+import { generateCodePath, type CodePathData } from "@/lib/generate-code-path";
 import { parseError } from "@/lib/parse-error";
 import { ErrorState } from "@/components/error-boundary";
-
-type ParsedResponse = {
-	codePathList: {
-		dot: string;
-	}[];
-};
 
 export const CodePath: FC = () => {
 	const explorer = useExplorer();
@@ -20,7 +14,7 @@ export const CodePath: FC = () => {
 	const { sourceType, esVersion, isJSX } = jsOptions;
 	const { pathView } = viewModes;
 	const { index, indexes } = pathIndex;
-	const [extracted, setExtracted] = useState<ParsedResponse | null>(null);
+	const [extracted, setExtracted] = useState<CodePathData[] | null>(null);
 	const [error, setError] = useState<string | null>(null);
 	const hasMountedDebouncedEffect = useRef(false);
 
@@ -36,18 +30,16 @@ export const CodePath: FC = () => {
 				if ("error" in response) {
 					throw new Error(response.error);
 				}
-				const newExtracted = JSON.parse(
-					response.response,
-				) as ParsedResponse;
-				if (newExtracted.codePathList.length < indexes) {
+				const newExtracted = response.response;
+				if (newExtracted.length < indexes) {
 					setPathIndex({
 						index: 0,
-						indexes: newExtracted.codePathList.length,
+						indexes: newExtracted.length,
 					});
 				} else {
 					setPathIndex({
 						index,
-						indexes: newExtracted.codePathList.length,
+						indexes: newExtracted.length,
 					});
 				}
 				setError(null);
@@ -88,7 +80,7 @@ export const CodePath: FC = () => {
 		return null;
 	}
 
-	const codePath = extracted.codePathList[index].dot;
+	const codePath = extracted[index].dot;
 
 	if (pathView === "code") {
 		return <Editor ariaLabel="Code Path" readOnly value={codePath} />;

--- a/src/lib/generate-code-path.ts
+++ b/src/lib/generate-code-path.ts
@@ -4,6 +4,10 @@ import { Linter } from "eslint-linter-browserify";
 import { CodePathStack } from "@/lib/code-path-stack";
 import type { SourceType, Version } from "@/hooks/use-explorer";
 
+export type CodePathData = {
+	dot: string;
+};
+
 const makeDotArrows = codePath => {
 	const stack = [{ segment: codePath.initialSegment, index: 0 }];
 	const done = Object.create(null);
@@ -66,7 +70,7 @@ export const generateCodePath = (
 			error: string;
 	  }
 	| {
-			response: string;
+			response: CodePathData[];
 	  } => {
 	const linter = new Linter({ configType: "flat" });
 
@@ -153,8 +157,8 @@ export const generateCodePath = (
 		};
 	}
 
-	const response = {
-		codePathList: allCodePaths.map(target => {
+	return {
+		response: allCodePaths.map(target => {
 			const { codePath } = target;
 
 			let text =
@@ -197,6 +201,4 @@ export const generateCodePath = (
 			};
 		}),
 	};
-
-	return { response: JSON.stringify(response, null, 2) };
 };


### PR DESCRIPTION
#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/.github/blob/master/CONTRIBUTING.md).

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Update or create tests
    - If performance-related, include a benchmark
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### AI acknowledgment

- [x] I did _not_ use AI to generate this PR.
- [ ] (If the above is not checked) I have reviewed the AI-generated content before submitting.

#### What is the purpose of this pull request?

Remove JSON serialization from code path generation.

#### What changes did you make? (Give an overview)

Returned the code path array directly through the response and updated the caller to use it without `JSON.parse()`.

#### Related Issues

refs #519

#### Is there anything you'd like reviewers to focus on?

x

Disclosure: I'm a participant of [open source contribution program OSSCA](https://github.com/eslint-ossca)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved code path handling for more reliable path counts and DOT output selection.
  * Updated code path results to display correctly using the returned data directly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->